### PR TITLE
core: add explicit sync support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ protocolnew("stable/viewporter" "viewporter" false)
 protocolnew("staging/cursor-shape" "cursor-shape-v1" false)
 protocolnew("stable/tablet" "tablet-v2" false)
 protocolnew("unstable/text-input" "text-input-unstable-v3" false)
+protocolnew("staging/linux-drm-syncobj" "linux-drm-syncobj-v1" false)
 protocolnew("protocols" "wlr-layer-shell-unstable-v1" true)
 
 # tests

--- a/src/core/Backend.hpp
+++ b/src/core/Backend.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <hyprtoolkit/core/Backend.hpp>
+#include <hyprutils/os/FileDescriptor.hpp>
+#include <hyprgraphics/resource/AsyncResourceGatherer.hpp>
+
+#include "../helpers/Env.hpp"
+#include "../helpers/Memory.hpp"
+
+namespace Hyprtoolkit {
+
+    class CPalette;
+    class CConfigManager;
+    class CSystemIconFactory;
+
+    class CBackend : public IBackend {
+      public:
+        CBackend();
+        virtual ~CBackend();
+
+        virtual void                   destroy();
+        virtual void                   setLogFn(LogFn&& fn);
+        virtual void                   addFd(int fd, std::function<void()>&& callback);
+        virtual void                   removeFd(int fd);
+        virtual SP<ISystemIconFactory> systemIcons();
+        virtual ASP<CTimer>  addTimer(const std::chrono::system_clock::duration& timeout, std::function<void(ASP<CTimer> self, void* data)> cb_, void* data, bool force = false);
+        virtual void         addIdle(const std::function<void()>& fn);
+        virtual void         enterLoop();
+        virtual SP<CPalette> getPalette();
+
+        // ======================= Internal fns ======================= //
+
+        void terminate();
+        void reloadTheme();
+        void rebuildPollfds();
+
+        // schedule function to when fd is readable (WL_EVENT_READABLE / POLLIN),
+        // takes ownership of fd
+        void        doOnReadable(Hyprutils::OS::CFileDescriptor fd, std::function<void()>&& fn);
+
+        SP<IWindow> openWindow(const SWindowCreationData& data);
+
+        //
+
+        std::vector<pollfd>                                     m_pollfds;
+
+        Hyprutils::Memory::CSharedPointer<Aquamarine::CBackend> m_aqBackend;
+
+        LogFn                                                   m_logFn;
+
+        bool                                                    m_terminate         = false;
+        bool                                                    m_needsConfigReload = false;
+
+        struct SFDListener {
+            Hyprutils::OS::CFileDescriptor fdOwned;
+            int                            fd = 0;
+            std::function<void()>          callback;
+            bool                           needsDispatch = false;
+            bool                           removeOnFire  = false;
+        };
+
+        struct {
+            std::mutex               timersMutex;
+            std::mutex               idlesMutex;
+            std::mutex               eventRequestMutex;
+            std::mutex               eventLoopMutex;
+            std::condition_variable  loopCV;
+            bool                     event = false;
+
+            std::condition_variable  wlDispatchCV;
+            bool                     wlDispatched = false;
+
+            std::condition_variable  timerCV;
+            std::mutex               timerRequestMutex;
+            bool                     timerEvent = false;
+
+            std::condition_variable  idleCV;
+            std::mutex               idleRequestMutex;
+            bool                     idleEvent = false;
+
+            int                      exitfd[2];
+
+            std::vector<SFDListener> userFds;
+        } m_sLoopState;
+
+        std::vector<Hyprutils::Memory::CAtomicSharedPointer<CTimer>>                m_timers;
+        std::vector<Hyprutils::Memory::CAtomicSharedPointer<std::function<void()>>> m_idles;
+    };
+}

--- a/src/core/InternalBackend.cpp
+++ b/src/core/InternalBackend.cpp
@@ -7,6 +7,9 @@
 
 using namespace Hyprtoolkit;
 
+IBackend::~IBackend() = default;
+IBackend::IBackend()  = default;
+
 void CBackendLogger::log(eLogLevel level, std::string str) {
     if (g_backend->m_logFn) {
         g_backend->m_logFn(level, str);

--- a/src/core/InternalBackend.hpp
+++ b/src/core/InternalBackend.hpp
@@ -4,6 +4,7 @@
 #include <hyprutils/os/FileDescriptor.hpp>
 #include <hyprgraphics/resource/AsyncResourceGatherer.hpp>
 
+#include "Backend.hpp"
 #include "../helpers/Env.hpp"
 
 namespace Hyprtoolkit {

--- a/src/core/platforms/WaylandPlatform.cpp
+++ b/src/core/platforms/WaylandPlatform.cpp
@@ -83,6 +83,10 @@ bool CWaylandPlatform::attempt() {
             TRACE(g_logger->log(HT_LOG_TRACE, "  > binding to global: {} (version {}) with id {}", name, 5, id));
             m_waylandState.layerShell =
                 makeShared<CCZwlrLayerShellV1>((wl_proxy*)wl_registry_bind((wl_registry*)m_waylandState.registry->resource(), id, &zwlr_layer_shell_v1_interface, 5));
+        } else if (NAME == wp_linux_drm_syncobj_manager_v1_interface.name) {
+            TRACE(g_logger->log(HT_LOG_TRACE, "  > binding to global: {} (version {}) with id {}", name, 1, id));
+            m_waylandState.syncobj = makeShared<CCWpLinuxDrmSyncobjManagerV1>(
+                (wl_proxy*)wl_registry_bind((wl_registry*)m_waylandState.registry->resource(), id, &wp_linux_drm_syncobj_manager_v1_interface, 1));
         } else if (NAME == "zwp_linux_dmabuf_v1") {
             TRACE(g_logger->log(HT_LOG_TRACE, "  > binding to global: {} (version {}) with id {}", name, 4, id));
             m_waylandState.dmabuf =

--- a/src/core/platforms/WaylandPlatform.hpp
+++ b/src/core/platforms/WaylandPlatform.hpp
@@ -22,6 +22,7 @@
 #include <cursor-shape-v1.hpp>
 #include <text-input-unstable-v3.hpp>
 #include <wlr-layer-shell-unstable-v1.hpp>
+#include <linux-drm-syncobj-v1.hpp>
 
 #include <aquamarine/allocator/GBM.hpp>
 #include <aquamarine/backend/Misc.hpp>
@@ -84,6 +85,7 @@ namespace Hyprtoolkit {
             Hyprutils::Memory::CSharedPointer<CCZwpTextInputManagerV3>      textInputManager;
             Hyprutils::Memory::CSharedPointer<CCZwpTextInputV3>             textInput;
             Hyprutils::Memory::CSharedPointer<CCZwlrLayerShellV1>           layerShell;
+            Hyprutils::Memory::CSharedPointer<CCWpLinuxDrmSyncobjManagerV1> syncobj;
 
             // control
             bool dmabufFailed = false;

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -16,6 +16,7 @@ using namespace Hyprgraphics;
 namespace Hyprtoolkit {
     class IToolkitWindow;
     class IRendererTexture;
+    class CSyncTimeline;
 
     class IRenderer {
       public:
@@ -60,6 +61,7 @@ namespace Hyprtoolkit {
         };
 
         virtual void                 beginRendering(SP<IToolkitWindow> window, SP<Aquamarine::IBuffer> buf) = 0;
+        virtual void                 render(bool ignoreSync = false)                                        = 0;
         virtual void                 endRendering()                                                         = 0;
         virtual void                 renderRectangle(const SRectangleRenderData& data)                      = 0;
         virtual SP<IRendererTexture> uploadTexture(const STextureData& data)                                = 0;
@@ -67,6 +69,11 @@ namespace Hyprtoolkit {
         virtual void                 renderBorder(const SBorderRenderData& data)                            = 0;
         virtual void                 renderPolygon(const SPolygonRenderData& data)                          = 0;
         virtual void                 renderLine(const SLineRenderData& data)                                = 0;
+        virtual void                 signalRenderPoint(SP<CSyncTimeline> timeline)                          = 0;
+
+        virtual SP<CSyncTimeline>    exportSync(SP<Aquamarine::IBuffer> buf) = 0;
+
+        virtual bool                 explicitSyncSupported() = 0;
     };
 
     inline SP<IRenderer> g_renderer;

--- a/src/renderer/gl/Renderbuffer.hpp
+++ b/src/renderer/gl/Renderbuffer.hpp
@@ -7,6 +7,9 @@
 
 namespace Hyprtoolkit {
 
+    class CSyncTimeline;
+    class CEGLSync;
+
     class CRenderbuffer {
       public:
         CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format);
@@ -20,6 +23,8 @@ namespace Hyprtoolkit {
         uint32_t                getFormat();
 
         WP<Aquamarine::IBuffer> m_hlBuffer;
+
+        SP<CSyncTimeline>       m_syncTimeline;
 
       private:
         void*        m_image = nullptr;

--- a/src/renderer/gl/Sync.cpp
+++ b/src/renderer/gl/Sync.cpp
@@ -1,0 +1,50 @@
+#include "Sync.hpp"
+#include "../../core/InternalBackend.hpp"
+
+using namespace Hyprtoolkit;
+using namespace Hyprutils::OS;
+
+UP<CEGLSync> CEGLSync::create() {
+    EGLSyncKHR sync = g_openGL->m_proc.eglCreateSyncKHR(g_openGL->m_eglDisplay, EGL_SYNC_NATIVE_FENCE_ANDROID, nullptr);
+
+    if (sync == EGL_NO_SYNC_KHR) {
+        g_logger->log(HT_LOG_ERROR, "eglCreateSyncKHR failed");
+        return nullptr;
+    }
+
+    // we need to flush otherwise we might not get a valid fd
+    glFlush();
+
+    int fd = g_openGL->m_proc.eglDupNativeFenceFDANDROID(g_openGL->m_eglDisplay, sync);
+    if (fd == EGL_NO_NATIVE_FENCE_FD_ANDROID) {
+        g_logger->log(HT_LOG_ERROR, "eglDupNativeFenceFDANDROID failed");
+        return nullptr;
+    }
+
+    UP<CEGLSync> eglSync(new CEGLSync);
+    eglSync->m_fd    = CFileDescriptor(fd);
+    eglSync->m_sync  = sync;
+    eglSync->m_valid = true;
+
+    return eglSync;
+}
+
+CEGLSync::~CEGLSync() {
+    if (m_sync == EGL_NO_SYNC_KHR)
+        return;
+
+    if (g_openGL && g_openGL->m_proc.eglDestroySyncKHR(g_openGL->m_eglDisplay, m_sync) != EGL_TRUE)
+        g_logger->log(HT_LOG_ERROR, "eglDestroySyncKHR failed");
+}
+
+CFileDescriptor& CEGLSync::fd() {
+    return m_fd;
+}
+
+CFileDescriptor&& CEGLSync::takeFd() {
+    return std::move(m_fd);
+}
+
+bool CEGLSync::isValid() {
+    return m_valid && m_sync != EGL_NO_SYNC_KHR && m_fd.isValid();
+}

--- a/src/renderer/gl/Sync.hpp
+++ b/src/renderer/gl/Sync.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "OpenGL.hpp"
+#include "../../helpers/Memory.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
+
+namespace Hyprtoolkit {
+    class CEGLSync {
+      public:
+        static UP<CEGLSync> create();
+
+        ~CEGLSync();
+
+        Hyprutils::OS::CFileDescriptor&  fd();
+        Hyprutils::OS::CFileDescriptor&& takeFd();
+        bool                             isValid();
+
+      private:
+        CEGLSync() = default;
+
+        Hyprutils::OS::CFileDescriptor m_fd;
+        EGLSyncKHR                     m_sync  = EGL_NO_SYNC_KHR;
+        bool                           m_valid = false;
+
+        friend class CHyprOpenGLImpl;
+    };
+}

--- a/src/renderer/sync/SyncTimeline.cpp
+++ b/src/renderer/sync/SyncTimeline.cpp
@@ -1,0 +1,159 @@
+#include "SyncTimeline.hpp"
+#include "../../Macros.hpp"
+#include "../../core/InternalBackend.hpp"
+#include "../Renderer.hpp"
+
+#include <xf86drm.h>
+#include <sys/eventfd.h>
+
+using namespace Hyprutils::OS;
+using namespace Hyprtoolkit;
+
+SP<CSyncTimeline> CSyncTimeline::create(int drmFD_) {
+    RASSERT(g_renderer->explicitSyncSupported(), "Tried to create a sync timeline without ES support");
+
+    auto timeline     = SP<CSyncTimeline>(new CSyncTimeline);
+    timeline->m_drmFD = drmFD_;
+    timeline->m_self  = timeline;
+
+    if (drmSyncobjCreate(drmFD_, 0, &timeline->m_handle)) {
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline: failed to create a drm syncobj??");
+        return nullptr;
+    }
+
+    int objFd = -1;
+    if (drmSyncobjHandleToFD(drmFD_, timeline->m_handle, &objFd)) {
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline: failed to get a syncobj fd??");
+        return nullptr;
+    }
+
+    timeline->m_syncobjFD = Hyprutils::OS::CFileDescriptor(objFd);
+
+    return timeline;
+}
+
+SP<CSyncTimeline> CSyncTimeline::create(int drmFD_, CFileDescriptor&& drmSyncobjFD) {
+    RASSERT(g_renderer->explicitSyncSupported(), "Tried to create a sync timeline without ES support");
+
+    auto timeline         = SP<CSyncTimeline>(new CSyncTimeline);
+    timeline->m_drmFD     = drmFD_;
+    timeline->m_syncobjFD = std::move(drmSyncobjFD);
+    timeline->m_self      = timeline;
+
+    if (drmSyncobjFDToHandle(drmFD_, timeline->m_syncobjFD.get(), &timeline->m_handle)) {
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline: failed to create a drm syncobj from fd??");
+        return nullptr;
+    }
+
+    return timeline;
+}
+
+CSyncTimeline::~CSyncTimeline() {
+    if (m_handle == 0)
+        return;
+
+    drmSyncobjDestroy(m_drmFD, m_handle);
+}
+
+std::optional<bool> CSyncTimeline::check(uint64_t point, uint32_t flags) {
+#ifdef __FreeBSD__
+    constexpr int ETIME_ERR = ETIMEDOUT;
+#else
+    constexpr int ETIME_ERR = ETIME;
+#endif
+
+    uint32_t signaled = 0;
+    int      ret      = drmSyncobjTimelineWait(m_drmFD, &m_handle, &point, 1, 0, flags, &signaled);
+    if (ret != 0 && ret != -ETIME_ERR) {
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline::check: drmSyncobjTimelineWait failed");
+        return std::nullopt;
+    }
+
+    return ret == 0;
+}
+
+bool CSyncTimeline::addWaiter(std::function<void()>&& waiter, uint64_t point, uint32_t flags) {
+    auto eventFd = CFileDescriptor(eventfd(0, EFD_CLOEXEC));
+
+    if (!eventFd.isValid()) {
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline::addWaiter: failed to acquire an eventfd");
+        return false;
+    }
+
+    if (drmSyncobjEventfd(m_drmFD, m_handle, point, eventFd.get(), flags)) {
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline::addWaiter: drmSyncobjEventfd failed");
+        return false;
+    }
+
+    g_backend->doOnReadable(std::move(eventFd), std::move(waiter));
+
+    return true;
+}
+
+CFileDescriptor CSyncTimeline::exportAsSyncFileFD(uint64_t src) {
+    int      sync = -1;
+
+    uint32_t syncHandle = 0;
+    if (drmSyncobjCreate(m_drmFD, 0, &syncHandle)) {
+        g_logger->log(HT_LOG_ERROR, "exportAsSyncFileFD: drmSyncobjCreate failed");
+        return {};
+    }
+
+    if (drmSyncobjTransfer(m_drmFD, syncHandle, 0, m_handle, src, 0)) {
+        g_logger->log(HT_LOG_ERROR, "exportAsSyncFileFD: drmSyncobjTransfer failed");
+        drmSyncobjDestroy(m_drmFD, syncHandle);
+        return {};
+    }
+
+    if (drmSyncobjExportSyncFile(m_drmFD, syncHandle, &sync)) {
+        g_logger->log(HT_LOG_ERROR, "exportAsSyncFileFD: drmSyncobjExportSyncFile failed");
+        drmSyncobjDestroy(m_drmFD, syncHandle);
+        return {};
+    }
+
+    drmSyncobjDestroy(m_drmFD, syncHandle);
+    return CFileDescriptor{sync};
+}
+
+bool CSyncTimeline::importFromSyncFileFD(uint64_t dst, CFileDescriptor& fd) {
+    uint32_t syncHandle = 0;
+
+    if (drmSyncobjCreate(m_drmFD, 0, &syncHandle)) {
+        g_logger->log(HT_LOG_ERROR, "importFromSyncFileFD: drmSyncobjCreate failed");
+        return false;
+    }
+
+    if (drmSyncobjImportSyncFile(m_drmFD, syncHandle, fd.get())) {
+        g_logger->log(HT_LOG_ERROR, "importFromSyncFileFD: drmSyncobjImportSyncFile failed");
+        drmSyncobjDestroy(m_drmFD, syncHandle);
+        return false;
+    }
+
+    if (drmSyncobjTransfer(m_drmFD, m_handle, dst, syncHandle, 0, 0)) {
+        g_logger->log(HT_LOG_ERROR, "importFromSyncFileFD: drmSyncobjTransfer failed");
+        drmSyncobjDestroy(m_drmFD, syncHandle);
+        return false;
+    }
+
+    drmSyncobjDestroy(m_drmFD, syncHandle);
+    return true;
+}
+
+bool CSyncTimeline::transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint) {
+    if (m_drmFD != from->m_drmFD) {
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline::transfer: cannot transfer timelines between gpus, {} -> {}", from->m_drmFD, m_drmFD);
+        return false;
+    }
+
+    if (drmSyncobjTransfer(m_drmFD, m_handle, toPoint, from->m_handle, fromPoint, 0)) {
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline::transfer: drmSyncobjTransfer failed");
+        return false;
+    }
+
+    return true;
+}
+
+void CSyncTimeline::signal(uint64_t point) {
+    if (drmSyncobjTimelineSignal(m_drmFD, &m_handle, &point, 1))
+        g_logger->log(HT_LOG_ERROR, "CSyncTimeline::signal: drmSyncobjTimelineSignal failed");
+}

--- a/src/renderer/sync/SyncTimeline.hpp
+++ b/src/renderer/sync/SyncTimeline.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <functional>
+#include <hyprutils/os/FileDescriptor.hpp>
+#include "../../helpers/Memory.hpp"
+
+/*
+    Yoinked from Hyprland.
+*/
+
+namespace Hyprtoolkit {
+    class CSyncTimeline {
+      public:
+        static SP<CSyncTimeline> create(int drmFD_);
+        static SP<CSyncTimeline> create(int drmFD_, Hyprutils::OS::CFileDescriptor&& drmSyncobjFD);
+        ~CSyncTimeline();
+
+        // check if the timeline point has been signaled
+        // flags: DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT or DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE
+        // std::nullopt on fail
+        std::optional<bool>            check(uint64_t point, uint32_t flags);
+
+        bool                           addWaiter(std::function<void()>&& waiter, uint64_t point, uint32_t flags);
+        Hyprutils::OS::CFileDescriptor exportAsSyncFileFD(uint64_t src);
+        bool                           importFromSyncFileFD(uint64_t dst, Hyprutils::OS::CFileDescriptor& fd);
+        bool                           transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);
+        void                           signal(uint64_t point);
+
+        int                            m_drmFD = -1;
+        Hyprutils::OS::CFileDescriptor m_syncobjFD;
+        uint32_t                       m_handle = 0;
+        WP<CSyncTimeline>              m_self;
+
+        uint64_t                       m_acquirePoint = 0, m_releasePoint = 1;
+
+      private:
+        CSyncTimeline() = default;
+    };
+}

--- a/src/window/IWaylandWindow.hpp
+++ b/src/window/IWaylandWindow.hpp
@@ -15,20 +15,26 @@
 #include <fractional-scale-v1.hpp>
 #include <viewporter.hpp>
 #include <text-input-unstable-v3.hpp>
+#include <linux-drm-syncobj-v1.hpp>
 
 #include <chrono>
 
 namespace Hyprtoolkit {
+    class CSyncTimeline;
+
     class CWaylandBuffer {
       public:
-        CWaylandBuffer(Hyprutils::Memory::CSharedPointer<Aquamarine::IBuffer> buffer);
+        CWaylandBuffer(SP<Aquamarine::IBuffer> buffer);
         ~CWaylandBuffer();
-        bool good();
+        bool              good();
 
-        bool pendingRelease = false;
+        bool              m_pendingRelease = false;
+        SP<CSyncTimeline> m_timeline;
+        bool              m_firstTimeIgnoreSync = true;
 
         struct {
-            Hyprutils::Memory::CSharedPointer<CCWlBuffer> buffer;
+            SP<CCWlBuffer>                    buffer;
+            SP<CCWpLinuxDrmSyncobjTimelineV1> syncTimeline;
         } m_waylandState;
 
         Hyprutils::Memory::CWeakPointer<Aquamarine::IBuffer> m_buffer;
@@ -58,6 +64,9 @@ namespace Hyprtoolkit {
         virtual void configure(const Hyprutils::Math::Vector2D& size, uint32_t serial);
         virtual void resizeSwapchain(const Hyprutils::Math::Vector2D& pixelSize);
 
+        void         prepareExplicit(SP<CWaylandBuffer>);
+        void         submitExplicit(SP<CWaylandBuffer>);
+
         float        m_fractionalScale = 1.0;
 
         bool         m_open                  = false;
@@ -68,6 +77,7 @@ namespace Hyprtoolkit {
             SP<CCXdgSurface>                        xdgSurface;
             SP<CCXdgToplevel>                       xdgToplevel;
             SP<CCWlCallback>                        frameCallback;
+            SP<CCWpLinuxDrmSyncobjSurfaceV1>        syncobjSurf;
 
             std::array<SP<CWaylandBuffer>, 2>       wlBuffers;
             SP<Aquamarine::CSwapchain>              swapchain;

--- a/tests/Controls.cpp
+++ b/tests/Controls.cpp
@@ -28,7 +28,7 @@ using namespace Hyprtoolkit;
 #define WP CWeakPointer
 #define UP CUniquePointer
 
-static SP<CBackend>             backend;
+static SP<IBackend>             backend;
 static SP<CSliderElement>       hiddenSlider;
 static SP<CColumnLayoutElement> mainLayout;
 static SP<IWindow>              window;
@@ -109,7 +109,7 @@ static SP<IElement> stretchLayout(std::string&& label, SP<IElement> control) {
 }
 
 int main(int argc, char** argv, char** envp) {
-    backend = CBackend::create();
+    backend = IBackend::create();
 
     //
     window = CWindowBuilder::begin() //

--- a/tests/Dialog.cpp
+++ b/tests/Dialog.cpp
@@ -21,10 +21,10 @@ using namespace Hyprtoolkit;
 #define WP CWeakPointer
 #define UP CUniquePointer
 
-static SP<CBackend> backend;
+static SP<IBackend> backend;
 
 int                 main(int argc, char** argv, char** envp) {
-    backend = CBackend::create();
+    backend = IBackend::create();
 
     //
     auto window = CWindowBuilder::begin()->preferredSize({480, 180})->minSize({480, 180})->maxSize({480, 180})->appTitle("Dialog")->appClass("hyprtoolkit-dialog")->commence();

--- a/tests/SimpleWindow.cpp
+++ b/tests/SimpleWindow.cpp
@@ -20,7 +20,7 @@ using namespace Hyprtoolkit;
 #define WP CWeakPointer
 #define UP CUniquePointer
 
-static SP<CBackend> backend;
+static SP<IBackend> backend;
 static size_t       buttonClicks = 1;
 
 static void         addTimer(SP<CRectangleElement> rect) {
@@ -35,7 +35,7 @@ static void         addTimer(SP<CRectangleElement> rect) {
 }
 
 int main(int argc, char** argv, char** envp) {
-    backend = CBackend::create();
+    backend = IBackend::create();
 
     //
     auto window = CWindowBuilder::begin()->preferredSize({640, 480})->appTitle("Hello World!")->appClass("hyprtoolkit")->commence();


### PR DESCRIPTION
Adds explicit sync support to the renderer. This is necessary for Nvidia to avoid flickers.

cc for testing @gulafaran, anyone with nvidia, mgpu, etc.

Just test the sample controls client (`./build/controls`). Explicit sync is automatically enabled if supported.

For making sure ES is used, launch with `WAYLAND_DEBUG=1`, and see if there are `wp_linux_drm_syncobj_surface_v1` calls, e.g. `wp_linux_drm_syncobj_surface_v1#28.set_acquire_point(...)`.

breaking API change `CBackend` -> `IBackend`
