### PR TITLE
feat: add lua bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ CMakeUserPresets.json
 
 build/
 .vscode/
+.idea/
+.zed/
 .cache/
 
 protocols/*.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,35 @@ if(NOT HAS_INOTIFY AND inotify_FOUND)
   target_link_libraries(hyprtoolkit PUBLIC PkgConfig::inotify)
 endif()
 
+# Optional Lua bindings
+option(HYPRTOOLKIT_WITH_LUA "Build with Lua scripting support" OFF)
+
+if(HYPRTOOLKIT_WITH_LUA)
+  find_package(Lua 5.4 REQUIRED)
+
+  include(FetchContent)
+  FetchContent_Declare(
+    sol2
+    GIT_REPOSITORY https://github.com/ThePhD/sol2.git
+    GIT_TAG develop)
+  FetchContent_MakeAvailable(sol2)
+
+  file(GLOB_RECURSE LUA_BINDING_SOURCES CONFIGURE_DEPENDS
+       "src/bindings/lua/*.cpp")
+  target_sources(hyprtoolkit PRIVATE ${LUA_BINDING_SOURCES})
+  target_link_libraries(hyprtoolkit PUBLIC ${LUA_LIBRARIES})
+  target_include_directories(hyprtoolkit PUBLIC ${LUA_INCLUDE_DIR})
+  target_link_libraries(hyprtoolkit PRIVATE sol2::sol2)
+  target_compile_definitions(hyprtoolkit PUBLIC HYPRTOOLKIT_LUA_ENABLED)
+
+  # Lua runner executable
+  add_executable(hyprtoolkit-lua "tests/LuaRunner.cpp")
+  target_include_directories(hyprtoolkit-lua PRIVATE "./src")
+  target_link_libraries(hyprtoolkit-lua PRIVATE hyprtoolkit PkgConfig::deps sol2::sol2)
+
+  message(STATUS "Lua bindings enabled")
+endif()
+
 # Protocols
 pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
 message(STATUS "Found wayland-protocols at ${WAYLAND_PROTOCOLS_DIR}")

--- a/examples/lua/simple_form.lua
+++ b/examples/lua/simple_form.lua
@@ -1,0 +1,377 @@
+-- Simple Form Example for Hyprtoolkit Lua Bindings
+-- This demonstrates creating a basic registration form using Lua
+
+-- Create the backend (entry point)
+local backend = IBackend.create()
+local palette = backend:getPalette()
+
+-- Helper function for palette text color
+local function textColor()
+    return palette.text
+end
+
+-- Helper function for palette background color
+local function bgColor()
+    return palette.background
+end
+
+-- Helper function for alternate base color
+local function altBaseColor()
+    return palette.alternateBase
+end
+
+-- Create main window
+local window = CWindowBuilder.begin()
+    :appTitle("Lua Form Example")
+    :appClass("hyprtoolkit-lua-form")
+    :preferredSize(Vector2D.new(450, 400))
+    :minSize(Vector2D.new(350, 300))
+    :commence()
+
+-- Background rectangle (fills window)
+local bg = CRectangleBuilder.begin()
+    :color(bgColor)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_PERCENT,
+        Vector2D.new(1, 1)
+    ))
+    :commence()
+
+window.m_rootElement:addChild(bg)
+
+-- Main content layout (column, centered)
+local mainLayout = CColumnLayoutBuilder.begin()
+    :gap(12)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_AUTO,
+        Vector2D.new(0.85, 1)
+    ))
+    :commence()
+
+mainLayout:setMargin(20)
+mainLayout:setPositionMode(PositionMode.ABSOLUTE)
+mainLayout:setPositionFlag(PositionFlag.HCENTER, true)
+
+bg:addChild(mainLayout)
+
+-- Title
+local title = CTextBuilder.begin()
+    :text("User Registration")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_H1, 1.0))
+    :color(textColor)
+    :align(FontAlignment.CENTER)
+    :commence()
+
+title:setPositionFlag(PositionFlag.HCENTER, true)
+mainLayout:addChild(title)
+
+-- Subtitle
+local subtitle = CTextBuilder.begin()
+    :text("Please fill in your details below")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_TEXT, 1.0))
+    :color(function()
+        return palette.text:darken(0.3)
+    end)
+    :align(FontAlignment.CENTER)
+    :commence()
+
+subtitle:setPositionFlag(PositionFlag.HCENTER, true)
+mainLayout:addChild(subtitle)
+
+-- Separator line
+local separator = CRectangleBuilder.begin()
+    :color(function()
+        return palette.text:darken(0.7)
+    end)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_ABSOLUTE,
+        Vector2D.new(0.6, 2)
+    ))
+    :commence()
+
+separator:setMargin(8)
+separator:setPositionFlag(PositionFlag.HCENTER, true)
+mainLayout:addChild(separator)
+
+-- Name field label
+local nameLabel = CTextBuilder.begin()
+    :text("Full Name:")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_TEXT, 1.0))
+    :color(textColor)
+    :commence()
+
+mainLayout:addChild(nameLabel)
+
+-- Name input field
+local nameInput = CTextboxBuilder.begin()
+    :placeholder("Enter your full name")
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_ABSOLUTE,
+        Vector2D.new(1, 32)
+    ))
+    :onTextEdited(function(textbox, text)
+        print("[Form] Name changed to: " .. text)
+    end)
+    :commence()
+
+mainLayout:addChild(nameInput)
+
+-- Email field label
+local emailLabel = CTextBuilder.begin()
+    :text("Email Address:")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_TEXT, 1.0))
+    :color(textColor)
+    :commence()
+
+mainLayout:addChild(emailLabel)
+
+-- Email input field
+local emailInput = CTextboxBuilder.begin()
+    :placeholder("you@example.com")
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_ABSOLUTE,
+        Vector2D.new(1, 32)
+    ))
+    :commence()
+
+mainLayout:addChild(emailInput)
+
+-- Priority slider row
+local sliderRow = CRowLayoutBuilder.begin()
+    :gap(12)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_AUTO,
+        Vector2D.new(1, 1)
+    ))
+    :commence()
+
+local sliderLabel = CTextBuilder.begin()
+    :text("Priority:")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_TEXT, 1.0))
+    :color(textColor)
+    :commence()
+
+local priorityValue = CTextBuilder.begin()
+    :text("5")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_TEXT, 1.0))
+    :color(function()
+        return palette.accent
+    end)
+    :commence()
+
+local prioritySlider = CSliderBuilder.begin()
+    :min(1)
+    :max(10)
+    :val(5)
+    :snapInt(true)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_ABSOLUTE,
+        Vector2D.new(0.5, 14)
+    ))
+    :onChanged(function(slider, value)
+        local intVal = math.floor(value + 0.5)
+        priorityValue:rebuild():text(tostring(intVal)):commence()
+        print("[Form] Priority set to: " .. intVal)
+    end)
+    :commence()
+
+sliderRow:addChild(sliderLabel)
+sliderRow:addChild(prioritySlider)
+sliderRow:addChild(priorityValue)
+mainLayout:addChild(sliderRow)
+
+-- Category dropdown
+local categoryRow = CRowLayoutBuilder.begin()
+    :gap(12)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_AUTO,
+        Vector2D.new(1, 1)
+    ))
+    :commence()
+
+local categoryLabel = CTextBuilder.begin()
+    :text("Category:")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_TEXT, 1.0))
+    :color(textColor)
+    :commence()
+
+local categoryCombo = CComboboxBuilder.begin()
+    :items({"General Inquiry", "Technical Support", "Sales", "Feedback", "Other"})
+    :currentItem(0)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_ABSOLUTE,
+        Vector2D.new(0.6, 28)
+    ))
+    :onChanged(function(combo, index)
+        print("[Form] Category selected: " .. tostring(index))
+    end)
+    :commence()
+
+categoryRow:addChild(categoryLabel)
+categoryRow:addChild(categoryCombo)
+mainLayout:addChild(categoryRow)
+
+-- Checkbox row for newsletter
+local checkboxRow = CRowLayoutBuilder.begin()
+    :gap(10)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_AUTO,
+        CDynamicSize.HT_SIZE_AUTO,
+        Vector2D.new(1, 1)
+    ))
+    :commence()
+
+-- Track checkbox state via local variable (state() method not yet implemented)
+local newsletterSubscribed = false
+
+local newsletterCheck = CCheckboxBuilder.begin()
+    :toggled(false)
+    :onToggled(function(checkbox, state)
+        newsletterSubscribed = state
+        print("[Form] Newsletter subscription: " .. tostring(state))
+    end)
+    :commence()
+
+local checkboxLabel = CTextBuilder.begin()
+    :text("Subscribe to newsletter")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_TEXT, 1.0))
+    :color(textColor)
+    :commence()
+
+checkboxRow:addChild(newsletterCheck)
+checkboxRow:addChild(checkboxLabel)
+mainLayout:addChild(checkboxRow)
+
+-- Terms checkbox
+local termsRow = CRowLayoutBuilder.begin()
+    :gap(10)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_AUTO,
+        CDynamicSize.HT_SIZE_AUTO,
+        Vector2D.new(1, 1)
+    ))
+    :commence()
+
+-- Track terms checkbox state via local variable
+local termsAccepted = false
+
+local termsCheck = CCheckboxBuilder.begin()
+    :toggled(false)
+    :onToggled(function(checkbox, state)
+        termsAccepted = state
+    end)
+    :commence()
+
+local termsLabel = CTextBuilder.begin()
+    :text("I agree to the terms and conditions")
+    :fontSize(CFontSize.new(CFontSize.HT_FONT_TEXT, 1.0))
+    :color(textColor)
+    :commence()
+
+termsRow:addChild(termsCheck)
+termsRow:addChild(termsLabel)
+mainLayout:addChild(termsRow)
+
+-- Spacer
+local spacer = CNullBuilder.begin()
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_ABSOLUTE,
+        CDynamicSize.HT_SIZE_ABSOLUTE,
+        Vector2D.new(0, 16)
+    ))
+    :commence()
+
+mainLayout:addChild(spacer)
+
+-- Button row
+local buttonRow = CRowLayoutBuilder.begin()
+    :gap(12)
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_PERCENT,
+        CDynamicSize.HT_SIZE_AUTO,
+        Vector2D.new(1, 1)
+    ))
+    :commence()
+
+-- Right-align buttons with a spacer
+local buttonSpacer = CNullBuilder.begin():commence()
+buttonSpacer:setGrow(true)
+
+-- Cancel button
+local cancelButton = CButtonBuilder.begin()
+    :label("Cancel")
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_AUTO,
+        CDynamicSize.HT_SIZE_AUTO,
+        Vector2D.new(1, 1)
+    ))
+    :onMainClick(function(btn)
+        print("[Form] Cancelled")
+        window:close()
+        backend:destroy()
+    end)
+    :commence()
+
+-- Submit button
+local submitButton = CButtonBuilder.begin()
+    :label("Submit")
+    :size(CDynamicSize.new(
+        CDynamicSize.HT_SIZE_AUTO,
+        CDynamicSize.HT_SIZE_AUTO,
+        Vector2D.new(1, 1)
+    ))
+    :onMainClick(function(btn)
+        local name = nameInput:currentText()
+        local email = emailInput:currentText()
+        local category = categoryCombo:current()
+
+        print("=== Form Submitted ===")
+        print("Name: " .. name)
+        print("Email: " .. email)
+        print("Category: " .. tostring(category))
+        print("Newsletter: " .. tostring(newsletterSubscribed))
+        print("Terms accepted: " .. tostring(termsAccepted))
+        print("======================")
+
+        if not termsAccepted then
+            print("[Error] You must accept the terms and conditions!")
+            return
+        end
+
+        if name == "" then
+            print("[Error] Name is required!")
+            return
+        end
+
+        -- Success - update button text
+        btn:rebuild():label("Submitted!"):commence()
+    end)
+    :commence()
+
+buttonRow:addChild(buttonSpacer)
+buttonRow:addChild(cancelButton)
+buttonRow:addChild(submitButton)
+mainLayout:addChild(buttonRow)
+
+-- Handle window close request
+window:onCloseRequest(function()
+    print("[Form] Window close requested")
+    window:close()
+    backend:destroy()
+end)
+
+-- Open window and run the event loop
+print("[Form] Starting application...")
+window:open()
+backend:enterLoop()
+
+print("[Form] Application exited")

--- a/src/bindings/lua/LuaBindings.cpp
+++ b/src/bindings/lua/LuaBindings.cpp
@@ -1,0 +1,40 @@
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include "LuaBindings.hpp"
+#include "LuaState.hpp"
+
+#include "helpers/SmartPtrAdapter.hpp"
+#include "helpers/CallbackAdapter.hpp"
+#include "helpers/ColorFnAdapter.hpp"
+
+using namespace Hyprutils::Memory;
+
+namespace Hyprtoolkit::Lua {
+
+void registerAllBindings(sol::state& lua) {
+    // 1. Basic types first (Vector2D, CBox, CHyprColor, etc.)
+    registerTypes(lua);
+
+    // 2. Core types (Backend, Timer, Output, Icons)
+    registerCore(lua);
+
+    // 3. Base element (IElement)
+    registerElement(lua);
+
+    // 4. All element builders and instances
+    registerElementBuilders(lua);
+
+    // 5. Window (depends on IElement)
+    registerWindow(lua);
+}
+
+CSharedPointer<CLuaState> createLuaState() {
+    auto state = makeShared<CLuaState>();
+    state->openLibs();
+    registerAllBindings(state->lua());
+    return state;
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/LuaBindings.hpp
+++ b/src/bindings/lua/LuaBindings.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <string>
+
+#include "LuaState.hpp"
+
+namespace Hyprtoolkit::Lua {
+
+// Forward declarations for registration functions
+void registerTypes(sol::state& lua);
+void registerCore(sol::state& lua);
+void registerElement(sol::state& lua);
+void registerElementBuilders(sol::state& lua);
+void registerWindow(sol::state& lua);
+
+// Register all hyprtoolkit bindings to an existing sol::state
+void registerAllBindings(sol::state& lua);
+
+// Create a new Lua state with all hyprtoolkit bindings registered
+Hyprutils::Memory::CSharedPointer<CLuaState> createLuaState();
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/LuaState.cpp
+++ b/src/bindings/lua/LuaState.cpp
@@ -1,0 +1,37 @@
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include "LuaState.hpp"
+
+namespace Hyprtoolkit::Lua {
+
+CLuaState::CLuaState() = default;
+
+CLuaState::~CLuaState() = default;
+
+sol::state& CLuaState::lua() {
+    return m_lua;
+}
+
+const sol::state& CLuaState::lua() const {
+    return m_lua;
+}
+
+void CLuaState::openLibs() {
+    m_lua.open_libraries(sol::lib::base, sol::lib::package, sol::lib::coroutine, sol::lib::string, sol::lib::os, sol::lib::math, sol::lib::table, sol::lib::io);
+}
+
+sol::protected_function_result CLuaState::doFile(const std::string& path) {
+    return m_lua.safe_script_file(path, sol::script_pass_on_error);
+}
+
+sol::protected_function_result CLuaState::doString(const std::string& code) {
+    return m_lua.safe_script(code, sol::script_pass_on_error);
+}
+
+bool CLuaState::has(const std::string& name) const {
+    return m_lua[name].valid();
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/LuaState.hpp
+++ b/src/bindings/lua/LuaState.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <string>
+
+namespace Hyprtoolkit::Lua {
+
+class CLuaState {
+  public:
+    CLuaState();
+    ~CLuaState();
+
+    // Non-copyable
+    CLuaState(const CLuaState&)            = delete;
+    CLuaState& operator=(const CLuaState&) = delete;
+
+    // Movable
+    CLuaState(CLuaState&&)            = default;
+    CLuaState& operator=(CLuaState&&) = default;
+
+    // Access the underlying sol::state
+    sol::state&       lua();
+    const sol::state& lua() const;
+
+    // Open standard Lua libraries
+    void openLibs();
+
+    // Execute a Lua script file
+    sol::protected_function_result doFile(const std::string& path);
+
+    // Execute a Lua string
+    sol::protected_function_result doString(const std::string& code);
+
+    // Get a global variable
+    template <typename T>
+    T get(const std::string& name) {
+        return m_lua[name].get<T>();
+    }
+
+    // Set a global variable
+    template <typename T>
+    void set(const std::string& name, T&& value) {
+        m_lua[name] = std::forward<T>(value);
+    }
+
+    // Check if a global exists
+    bool has(const std::string& name) const;
+
+  private:
+    sol::state m_lua;
+};
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/bindings/Core.cpp
+++ b/src/bindings/lua/bindings/Core.cpp
@@ -1,0 +1,129 @@
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprtoolkit/core/Backend.hpp>
+#include <hyprtoolkit/core/Timer.hpp>
+#include <hyprtoolkit/core/Output.hpp>
+#include <hyprtoolkit/system/Icons.hpp>
+
+#include "../helpers/SmartPtrAdapter.hpp"
+#include "../helpers/CallbackAdapter.hpp"
+
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::Math;
+
+namespace Hyprtoolkit::Lua {
+
+void registerTimer(sol::state& lua) {
+    lua.new_usertype<CTimer>("CTimer",
+        sol::no_constructor,
+        "cancel", &CTimer::cancel,
+        "passed", &CTimer::passed,
+        "canForceUpdate", &CTimer::canForceUpdate,
+        "leftMs", &CTimer::leftMs,
+        "cancelled", &CTimer::cancelled,
+        "updateTimeout", [](CTimer* self, double timeoutMs) {
+            self->updateTimeout(std::chrono::milliseconds(static_cast<int64_t>(timeoutMs)));
+        }
+    );
+}
+
+void registerOutput(sol::state& lua) {
+    lua.new_usertype<IOutput>("IOutput",
+        sol::no_constructor,
+        "handle", &IOutput::handle,
+        "port", &IOutput::port,
+        "desc", &IOutput::desc,
+        "fps", &IOutput::fps
+        // Note: m_events.removed signal would need special handling
+    );
+}
+
+void registerSystemIcons(sol::state& lua) {
+    lua.new_usertype<ISystemIconDescription>("ISystemIconDescription",
+        sol::no_constructor,
+        "exists", &ISystemIconDescription::exists,
+        "scalable", &ISystemIconDescription::scalable
+    );
+
+    lua.new_usertype<ISystemIconFactory>("ISystemIconFactory",
+        sol::no_constructor,
+        "lookupIcon", &ISystemIconFactory::lookupIcon
+    );
+}
+
+void registerBackend(sol::state& lua) {
+    // Backend creation data
+    lua.new_usertype<IBackend::SBackendCreationData>("BackendCreationData",
+        sol::constructors<IBackend::SBackendCreationData()>()
+    );
+
+    lua.new_usertype<IBackend>("IBackend",
+        sol::no_constructor,
+
+        // Static factory methods
+        "create", &IBackend::create,
+        "createWithData", &IBackend::createWithData,
+
+        // Instance methods
+        "destroy", &IBackend::destroy,
+        "enterLoop", &IBackend::enterLoop,
+        "getPalette", &IBackend::getPalette,
+        "systemIcons", &IBackend::systemIcons,
+        "getOutputs", &IBackend::getOutputs,
+
+        // Timer with Lua callback (timeout in milliseconds)
+        "addTimer", [](CSharedPointer<IBackend> self, double timeoutMs, sol::function callback) {
+            auto duration = std::chrono::milliseconds(static_cast<int64_t>(timeoutMs));
+            return self->addTimer(
+                duration,
+                [callback](CAtomicSharedPointer<CTimer> timer, void*) {
+                    sol::protected_function_result result = callback(timer);
+                    if (!result.valid()) {
+                        sol::error err = result;
+                        fprintf(stderr, "[Lua] Timer callback error: %s\n", err.what());
+                    }
+                },
+                nullptr,
+                false
+            );
+        },
+
+        // Idle with Lua callback
+        "addIdle", [](CSharedPointer<IBackend> self, sol::function callback) {
+            self->addIdle([callback]() {
+                sol::protected_function_result result = callback();
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Idle callback error: %s\n", err.what());
+                }
+            });
+        },
+
+        // File descriptor callbacks
+        "addFd", [](CSharedPointer<IBackend> self, int fd, sol::function callback) {
+            self->addFd(fd, [callback]() {
+                sol::protected_function_result result = callback();
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Fd callback error: %s\n", err.what());
+                }
+            });
+        },
+        "removeFd", &IBackend::removeFd
+
+        // Note: Events (outputAdded) would need signal binding infrastructure
+    );
+}
+
+// Main registration function for all core types
+void registerCore(sol::state& lua) {
+    registerTimer(lua);
+    registerOutput(lua);
+    registerSystemIcons(lua);
+    registerBackend(lua);
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/bindings/ElementBuilders.cpp
+++ b/src/bindings/lua/bindings/ElementBuilders.cpp
@@ -1,0 +1,502 @@
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprtoolkit/element/Text.hpp>
+#include <hyprtoolkit/element/Button.hpp>
+#include <hyprtoolkit/element/Textbox.hpp>
+#include <hyprtoolkit/element/Checkbox.hpp>
+#include <hyprtoolkit/element/Slider.hpp>
+#include <hyprtoolkit/element/Combobox.hpp>
+#include <hyprtoolkit/element/Spinbox.hpp>
+#include <hyprtoolkit/element/Rectangle.hpp>
+#include <hyprtoolkit/element/ColumnLayout.hpp>
+#include <hyprtoolkit/element/RowLayout.hpp>
+#include <hyprtoolkit/element/ScrollArea.hpp>
+#include <hyprtoolkit/element/Image.hpp>
+#include <hyprtoolkit/element/Null.hpp>
+#include <hyprtoolkit/element/Line.hpp>
+#include <hyprtoolkit/types/ImageTypes.hpp>
+
+#include "../helpers/SmartPtrAdapter.hpp"
+#include "../helpers/CallbackAdapter.hpp"
+#include "../helpers/ColorFnAdapter.hpp"
+
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::Math;
+
+namespace Hyprtoolkit::Lua {
+
+// Text Element
+void registerTextElement(sol::state& lua) {
+    lua.new_usertype<CTextBuilder>("CTextBuilder",
+        sol::no_constructor,
+        "begin", &CTextBuilder::begin,
+        "text", [](CSharedPointer<CTextBuilder> self, const std::string& t) {
+            return self->text(std::string(t));
+        },
+        "color", [](CSharedPointer<CTextBuilder> self, sol::object colorObj) {
+            return self->color(luaToColorFn(colorObj));
+        },
+        "a", &CTextBuilder::a,
+        "fontSize", [](CSharedPointer<CTextBuilder> self, CFontSize fontSize) {
+            return self->fontSize(std::move(fontSize));
+        },
+        "align", &CTextBuilder::align,
+        "fontFamily", [](CSharedPointer<CTextBuilder> self, const std::string& f) {
+            return self->fontFamily(std::string(f));
+        },
+        "clampSize", [](CSharedPointer<CTextBuilder> self, double x, double y) {
+            return self->clampSize(Vector2D{x, y});
+        },
+        "callback", [](CSharedPointer<CTextBuilder> self, sol::function fn) {
+            return self->callback([fn]() {
+                sol::protected_function_result result = fn();
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Text callback error: %s\n", err.what());
+                }
+            });
+        },
+        "noEllipsize", &CTextBuilder::noEllipsize,
+        "size", [](CSharedPointer<CTextBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "async", &CTextBuilder::async,
+        "commence", &CTextBuilder::commence
+    );
+
+    lua.new_usertype<CTextElement>("CTextElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CTextElement::rebuild,
+        "size", &CTextElement::size
+    );
+}
+
+// Button Element
+void registerButtonElement(sol::state& lua) {
+    lua.new_usertype<CButtonBuilder>("CButtonBuilder",
+        sol::no_constructor,
+        "begin", &CButtonBuilder::begin,
+        "label", [](CSharedPointer<CButtonBuilder> self, const std::string& l) {
+            return self->label(std::string(l));
+        },
+        "noBorder", &CButtonBuilder::noBorder,
+        "noBg", &CButtonBuilder::noBg,
+        "alignText", &CButtonBuilder::alignText,
+        "fontFamily", [](CSharedPointer<CButtonBuilder> self, const std::string& f) {
+            return self->fontFamily(std::string(f));
+        },
+        "fontSize", [](CSharedPointer<CButtonBuilder> self, CFontSize fontSize) {
+            return self->fontSize(std::move(fontSize));
+        },
+        "onMainClick", [](CSharedPointer<CButtonBuilder> self, sol::function fn) {
+            return self->onMainClick([fn](CSharedPointer<CButtonElement> el) {
+                sol::protected_function_result result = fn(el);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Button onMainClick error: %s\n", err.what());
+                }
+            });
+        },
+        "onRightClick", [](CSharedPointer<CButtonBuilder> self, sol::function fn) {
+            return self->onRightClick([fn](CSharedPointer<CButtonElement> el) {
+                sol::protected_function_result result = fn(el);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Button onRightClick error: %s\n", err.what());
+                }
+            });
+        },
+        "size", [](CSharedPointer<CButtonBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CButtonBuilder::commence
+    );
+
+    lua.new_usertype<CButtonElement>("CButtonElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CButtonElement::rebuild,
+        "size", &CButtonElement::size
+    );
+}
+
+// Textbox Element
+void registerTextboxElement(sol::state& lua) {
+    lua.new_usertype<CTextboxBuilder>("CTextboxBuilder",
+        sol::no_constructor,
+        "begin", &CTextboxBuilder::begin,
+        "placeholder", [](CSharedPointer<CTextboxBuilder> self, const std::string& p) {
+            return self->placeholder(std::string(p));
+        },
+        "defaultText", [](CSharedPointer<CTextboxBuilder> self, const std::string& t) {
+            return self->defaultText(std::string(t));
+        },
+        "onTextEdited", [](CSharedPointer<CTextboxBuilder> self, sol::function fn) {
+            return self->onTextEdited([fn](CSharedPointer<CTextboxElement> el, const std::string& text) {
+                sol::protected_function_result result = fn(el, text);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Textbox onTextEdited error: %s\n", err.what());
+                }
+            });
+        },
+        "multiline", &CTextboxBuilder::multiline,
+        "size", [](CSharedPointer<CTextboxBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CTextboxBuilder::commence
+    );
+
+    lua.new_usertype<CTextboxElement>("CTextboxElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CTextboxElement::rebuild,
+        "size", &CTextboxElement::size,
+        "focus", &CTextboxElement::focus,
+        "currentText", [](CTextboxElement* self) {
+            return std::string(self->currentText());
+        }
+    );
+}
+
+// Checkbox Element
+void registerCheckboxElement(sol::state& lua) {
+    lua.new_usertype<CCheckboxBuilder>("CCheckboxBuilder",
+        sol::no_constructor,
+        "begin", &CCheckboxBuilder::begin,
+        "toggled", &CCheckboxBuilder::toggled,
+        "onToggled", [](CSharedPointer<CCheckboxBuilder> self, sol::function fn) {
+            return self->onToggled([fn](CSharedPointer<CCheckboxElement> el, bool state) {
+                sol::protected_function_result result = fn(el, state);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Checkbox onToggled error: %s\n", err.what());
+                }
+            });
+        },
+        "size", [](CSharedPointer<CCheckboxBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CCheckboxBuilder::commence
+    );
+
+    lua.new_usertype<CCheckboxElement>("CCheckboxElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CCheckboxElement::rebuild,
+        "size", &CCheckboxElement::size
+    );
+}
+
+// Slider Element
+void registerSliderElement(sol::state& lua) {
+    lua.new_usertype<CSliderBuilder>("CSliderBuilder",
+        sol::no_constructor,
+        "begin", &CSliderBuilder::begin,
+        "min", &CSliderBuilder::min,
+        "max", &CSliderBuilder::max,
+        "val", &CSliderBuilder::val,
+        "snapInt", &CSliderBuilder::snapInt,
+        "onChanged", [](CSharedPointer<CSliderBuilder> self, sol::function fn) {
+            return self->onChanged([fn](CSharedPointer<CSliderElement> el, float value) {
+                sol::protected_function_result result = fn(el, value);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Slider onChanged error: %s\n", err.what());
+                }
+            });
+        },
+        "size", [](CSharedPointer<CSliderBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CSliderBuilder::commence
+    );
+
+    lua.new_usertype<CSliderElement>("CSliderElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CSliderElement::rebuild,
+        "size", &CSliderElement::size,
+        "sliding", &CSliderElement::sliding
+    );
+}
+
+// Combobox Element
+void registerComboboxElement(sol::state& lua) {
+    lua.new_usertype<CComboboxBuilder>("CComboboxBuilder",
+        sol::no_constructor,
+        "begin", &CComboboxBuilder::begin,
+        "items", [](CSharedPointer<CComboboxBuilder> self, sol::table itemsTable) {
+            std::vector<std::string> items;
+            for (size_t i = 1; i <= itemsTable.size(); ++i) {
+                items.push_back(itemsTable[i].get<std::string>());
+            }
+            return self->items(std::move(items));
+        },
+        "currentItem", &CComboboxBuilder::currentItem,
+        "onChanged", [](CSharedPointer<CComboboxBuilder> self, sol::function fn) {
+            return self->onChanged([fn](CSharedPointer<CComboboxElement> el, size_t idx) {
+                sol::protected_function_result result = fn(el, idx);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Combobox onChanged error: %s\n", err.what());
+                }
+            });
+        },
+        "size", [](CSharedPointer<CComboboxBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CComboboxBuilder::commence
+    );
+
+    lua.new_usertype<CComboboxElement>("CComboboxElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CComboboxElement::rebuild,
+        "size", &CComboboxElement::size,
+        "current", &CComboboxElement::current,
+        "setCurrent", &CComboboxElement::setCurrent
+    );
+}
+
+// Spinbox Element
+void registerSpinboxElement(sol::state& lua) {
+    lua.new_usertype<CSpinboxBuilder>("CSpinboxBuilder",
+        sol::no_constructor,
+        "begin", &CSpinboxBuilder::begin,
+        "label", [](CSharedPointer<CSpinboxBuilder> self, const std::string& l) {
+            return self->label(std::string(l));
+        },
+        "items", [](CSharedPointer<CSpinboxBuilder> self, sol::table itemsTable) {
+            std::vector<std::string> items;
+            for (size_t i = 1; i <= itemsTable.size(); ++i) {
+                items.push_back(itemsTable[i].get<std::string>());
+            }
+            return self->items(std::move(items));
+        },
+        "currentItem", &CSpinboxBuilder::currentItem,
+        "onChanged", [](CSharedPointer<CSpinboxBuilder> self, sol::function fn) {
+            return self->onChanged([fn](CSharedPointer<CSpinboxElement> el, size_t idx) {
+                sol::protected_function_result result = fn(el, idx);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Spinbox onChanged error: %s\n", err.what());
+                }
+            });
+        },
+        "fill", &CSpinboxBuilder::fill,
+        "size", [](CSharedPointer<CSpinboxBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CSpinboxBuilder::commence
+    );
+
+    lua.new_usertype<CSpinboxElement>("CSpinboxElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CSpinboxElement::rebuild,
+        "size", &CSpinboxElement::size,
+        "current", &CSpinboxElement::current,
+        "setCurrent", &CSpinboxElement::setCurrent
+    );
+}
+
+// Rectangle Element
+void registerRectangleElement(sol::state& lua) {
+    lua.new_usertype<CRectangleBuilder>("CRectangleBuilder",
+        sol::no_constructor,
+        "begin", &CRectangleBuilder::begin,
+        "color", [](CSharedPointer<CRectangleBuilder> self, sol::object colorObj) {
+            return self->color(luaToColorFn(colorObj));
+        },
+        "borderColor", [](CSharedPointer<CRectangleBuilder> self, sol::object colorObj) {
+            return self->borderColor(luaToColorFn(colorObj));
+        },
+        "rounding", &CRectangleBuilder::rounding,
+        "borderThickness", &CRectangleBuilder::borderThickness,
+        "size", [](CSharedPointer<CRectangleBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CRectangleBuilder::commence
+    );
+
+    lua.new_usertype<CRectangleElement>("CRectangleElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CRectangleElement::rebuild,
+        "size", &CRectangleElement::size
+    );
+}
+
+// Column Layout Element
+void registerColumnLayoutElement(sol::state& lua) {
+    lua.new_usertype<CColumnLayoutBuilder>("CColumnLayoutBuilder",
+        sol::no_constructor,
+        "begin", &CColumnLayoutBuilder::begin,
+        "gap", &CColumnLayoutBuilder::gap,
+        "size", [](CSharedPointer<CColumnLayoutBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CColumnLayoutBuilder::commence
+    );
+
+    lua.new_usertype<CColumnLayoutElement>("CColumnLayoutElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CColumnLayoutElement::rebuild,
+        "size", &CColumnLayoutElement::size
+    );
+}
+
+// Row Layout Element
+void registerRowLayoutElement(sol::state& lua) {
+    lua.new_usertype<CRowLayoutBuilder>("CRowLayoutBuilder",
+        sol::no_constructor,
+        "begin", &CRowLayoutBuilder::begin,
+        "gap", &CRowLayoutBuilder::gap,
+        "size", [](CSharedPointer<CRowLayoutBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CRowLayoutBuilder::commence
+    );
+
+    lua.new_usertype<CRowLayoutElement>("CRowLayoutElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "size", &CRowLayoutElement::size
+    );
+}
+
+// Scroll Area Element
+void registerScrollAreaElement(sol::state& lua) {
+    lua.new_usertype<CScrollAreaBuilder>("CScrollAreaBuilder",
+        sol::no_constructor,
+        "begin", &CScrollAreaBuilder::begin,
+        "scrollX", &CScrollAreaBuilder::scrollX,
+        "scrollY", &CScrollAreaBuilder::scrollY,
+        "blockUserScroll", &CScrollAreaBuilder::blockUserScroll,
+        "size", [](CSharedPointer<CScrollAreaBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CScrollAreaBuilder::commence
+    );
+
+    lua.new_usertype<CScrollAreaElement>("CScrollAreaElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "size", &CScrollAreaElement::size,
+        "getCurrentScroll", &CScrollAreaElement::getCurrentScroll,
+        "setScroll", &CScrollAreaElement::setScroll
+    );
+}
+
+// Image Element
+void registerImageElement(sol::state& lua) {
+    // Image fit mode enum
+    lua.new_enum<eImageFitMode>("ImageFitMode",
+        {
+            {"STRETCH", IMAGE_FIT_MODE_STRETCH},
+            {"COVER", IMAGE_FIT_MODE_COVER},
+            {"CONTAIN", IMAGE_FIT_MODE_CONTAIN},
+            {"TILE", IMAGE_FIT_MODE_TILE}
+        }
+    );
+
+    lua.new_usertype<CImageBuilder>("CImageBuilder",
+        sol::no_constructor,
+        "begin", &CImageBuilder::begin,
+        "path", [](CSharedPointer<CImageBuilder> self, const std::string& p) {
+            return self->path(std::string(p));
+        },
+        "icon", &CImageBuilder::icon,
+        "a", &CImageBuilder::a,
+        "fitMode", &CImageBuilder::fitMode,
+        "sync", &CImageBuilder::sync,
+        "rounding", &CImageBuilder::rounding,
+        "size", [](CSharedPointer<CImageBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CImageBuilder::commence
+    );
+
+    lua.new_usertype<CImageElement>("CImageElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CImageElement::rebuild,
+        "size", &CImageElement::size
+    );
+}
+
+// Null Element (Spacer)
+void registerNullElement(sol::state& lua) {
+    lua.new_usertype<CNullBuilder>("CNullBuilder",
+        sol::no_constructor,
+        "begin", &CNullBuilder::begin,
+        "size", [](CSharedPointer<CNullBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CNullBuilder::commence
+    );
+
+    lua.new_usertype<CNullElement>("CNullElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CNullElement::rebuild,
+        "size", &CNullElement::size
+    );
+}
+
+// Line Element
+void registerLineElement(sol::state& lua) {
+    lua.new_usertype<CLineBuilder>("CLineBuilder",
+        sol::no_constructor,
+        "begin", &CLineBuilder::begin,
+        "color", [](CSharedPointer<CLineBuilder> self, sol::object colorObj) {
+            return self->color(luaToColorFn(colorObj));
+        },
+        "thick", &CLineBuilder::thick,
+        "points", [](CSharedPointer<CLineBuilder> self, sol::table pointsTable) {
+            std::vector<Vector2D> points;
+            for (size_t i = 1; i <= pointsTable.size(); ++i) {
+                sol::table pt = pointsTable[i];
+                points.push_back(Vector2D{pt[1].get<double>(), pt[2].get<double>()});
+            }
+            return self->points(std::move(points));
+        },
+        "size", [](CSharedPointer<CLineBuilder> self, CDynamicSize size) {
+            return self->size(std::move(size));
+        },
+        "commence", &CLineBuilder::commence
+    );
+
+    lua.new_usertype<CLineElement>("CLineElement",
+        sol::no_constructor,
+        sol::base_classes, sol::bases<IElement>(),
+        "rebuild", &CLineElement::rebuild,
+        "size", &CLineElement::size
+    );
+}
+
+// Main registration function for all element builders
+void registerElementBuilders(sol::state& lua) {
+    registerTextElement(lua);
+    registerButtonElement(lua);
+    registerTextboxElement(lua);
+    registerCheckboxElement(lua);
+    registerSliderElement(lua);
+    registerComboboxElement(lua);
+    registerSpinboxElement(lua);
+    registerRectangleElement(lua);
+    registerColumnLayoutElement(lua);
+    registerRowLayoutElement(lua);
+    registerScrollAreaElement(lua);
+    registerImageElement(lua);
+    registerNullElement(lua);
+    registerLineElement(lua);
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/bindings/Elements.cpp
+++ b/src/bindings/lua/bindings/Elements.cpp
@@ -1,0 +1,185 @@
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprtoolkit/element/Element.hpp>
+#include <hyprtoolkit/element/Text.hpp>
+#include <hyprtoolkit/element/Button.hpp>
+#include <hyprtoolkit/element/Textbox.hpp>
+#include <hyprtoolkit/element/Checkbox.hpp>
+#include <hyprtoolkit/element/Slider.hpp>
+#include <hyprtoolkit/element/Combobox.hpp>
+#include <hyprtoolkit/element/Spinbox.hpp>
+#include <hyprtoolkit/element/Rectangle.hpp>
+#include <hyprtoolkit/element/ColumnLayout.hpp>
+#include <hyprtoolkit/element/RowLayout.hpp>
+#include <hyprtoolkit/element/ScrollArea.hpp>
+#include <hyprtoolkit/element/Image.hpp>
+#include <hyprtoolkit/element/Null.hpp>
+#include <hyprtoolkit/element/Line.hpp>
+#include <hyprtoolkit/core/Input.hpp>
+
+#include "../helpers/SmartPtrAdapter.hpp"
+#include "../helpers/CallbackAdapter.hpp"
+
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::Math;
+
+namespace Hyprtoolkit::Lua {
+
+void registerElement(sol::state& lua) {
+    // Position mode enum
+    lua.new_enum<IElement::ePositionMode>("PositionMode",
+        {
+            {"ABSOLUTE", IElement::HT_POSITION_ABSOLUTE},
+            {"AUTO", IElement::HT_POSITION_AUTO}
+        }
+    );
+
+    // Position flag enum
+    lua.new_enum<IElement::ePositionFlag>("PositionFlag",
+        {
+            {"HCENTER", IElement::HT_POSITION_FLAG_HCENTER},
+            {"VCENTER", IElement::HT_POSITION_FLAG_VCENTER},
+            {"CENTER", IElement::HT_POSITION_FLAG_CENTER},
+            {"LEFT", IElement::HT_POSITION_FLAG_LEFT},
+            {"RIGHT", IElement::HT_POSITION_FLAG_RIGHT},
+            {"TOP", IElement::HT_POSITION_FLAG_TOP},
+            {"BOTTOM", IElement::HT_POSITION_FLAG_BOTTOM},
+            {"ALL", IElement::HT_POSITION_FLAG_ALL}
+        }
+    );
+
+    lua.new_usertype<IElement>("IElement",
+        sol::no_constructor,
+
+        // Size and position
+        "size", &IElement::size,
+        "posFromParent", &IElement::posFromParent,
+        "reposition", &IElement::reposition,
+        "forceReposition", &IElement::forceReposition,
+
+        // Position mode and flags
+        "setPositionMode", &IElement::setPositionMode,
+        "setPositionFlag", &IElement::setPositionFlag,
+        "setAbsolutePosition", &IElement::setAbsolutePosition,
+
+        // Child management - use lambda to handle derived element types
+        "addChild", [](IElement* self, sol::object child) {
+            // Try to extract as CSharedPointer<IElement>
+            if (child.is<CSharedPointer<IElement>>()) {
+                self->addChild(child.as<CSharedPointer<IElement>>());
+                return;
+            }
+            // Try common element types that inherit from IElement
+            // The sol::bases doesn't automatically convert smart pointers
+            #define TRY_ELEMENT_TYPE(T) \
+                if (child.is<CSharedPointer<T>>()) { \
+                    auto ptr = child.as<CSharedPointer<T>>(); \
+                    self->addChild(CSharedPointer<IElement>(ptr)); \
+                    return; \
+                }
+
+            // All element types need to be listed here for proper conversion
+            TRY_ELEMENT_TYPE(CTextElement)
+            TRY_ELEMENT_TYPE(CButtonElement)
+            TRY_ELEMENT_TYPE(CTextboxElement)
+            TRY_ELEMENT_TYPE(CCheckboxElement)
+            TRY_ELEMENT_TYPE(CSliderElement)
+            TRY_ELEMENT_TYPE(CComboboxElement)
+            TRY_ELEMENT_TYPE(CSpinboxElement)
+            TRY_ELEMENT_TYPE(CRectangleElement)
+            TRY_ELEMENT_TYPE(CColumnLayoutElement)
+            TRY_ELEMENT_TYPE(CRowLayoutElement)
+            TRY_ELEMENT_TYPE(CScrollAreaElement)
+            TRY_ELEMENT_TYPE(CImageElement)
+            TRY_ELEMENT_TYPE(CNullElement)
+            TRY_ELEMENT_TYPE(CLineElement)
+
+            #undef TRY_ELEMENT_TYPE
+
+            throw std::runtime_error("addChild: argument is not a valid element type");
+        },
+        "removeChild", &IElement::removeChild,
+        "clearChildren", &IElement::clearChildren,
+
+        // Styling
+        "setMargin", &IElement::setMargin,
+        "setGrouped", &IElement::setGrouped,
+        "setTooltip", [](IElement* self, const std::string& tooltip) {
+            self->setTooltip(std::string(tooltip));
+        },
+
+        // Growth
+        "setGrow", sol::overload(
+            static_cast<void (IElement::*)(bool)>(&IElement::setGrow),
+            static_cast<void (IElement::*)(bool, bool)>(&IElement::setGrow)
+        ),
+
+        // Mouse input
+        "setReceivesMouse", &IElement::setReceivesMouse,
+
+        "setMouseEnter", [](IElement* self, sol::function fn) {
+            self->setMouseEnter([fn](const Vector2D& pos) {
+                sol::protected_function_result result = fn(pos);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] mouseEnter callback error: %s\n", err.what());
+                }
+            });
+        },
+
+        "setMouseLeave", [](IElement* self, sol::function fn) {
+            self->setMouseLeave([fn]() {
+                sol::protected_function_result result = fn();
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] mouseLeave callback error: %s\n", err.what());
+                }
+            });
+        },
+
+        "setMouseMove", [](IElement* self, sol::function fn) {
+            self->setMouseMove([fn](const Vector2D& pos) {
+                sol::protected_function_result result = fn(pos);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] mouseMove callback error: %s\n", err.what());
+                }
+            });
+        },
+
+        "setMouseButton", [](IElement* self, sol::function fn) {
+            self->setMouseButton([fn](Input::eMouseButton button, bool pressed) {
+                sol::protected_function_result result = fn(button, pressed);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] mouseButton callback error: %s\n", err.what());
+                }
+            });
+        },
+
+        "setMouseAxis", [](IElement* self, sol::function fn) {
+            self->setMouseAxis([fn](Input::eAxisAxis axis, float delta) {
+                sol::protected_function_result result = fn(axis, delta);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] mouseAxis callback error: %s\n", err.what());
+                }
+            });
+        },
+
+        "setRepositioned", [](IElement* self, sol::function fn) {
+            self->setRepositioned([fn]() {
+                sol::protected_function_result result = fn();
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] repositioned callback error: %s\n", err.what());
+                }
+            });
+        }
+    );
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/bindings/Types.cpp
+++ b/src/bindings/lua/bindings/Types.cpp
@@ -1,0 +1,279 @@
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+#include <hyprutils/math/Box.hpp>
+#include <hyprtoolkit/palette/Color.hpp>
+#include <hyprtoolkit/palette/Palette.hpp>
+#include <hyprtoolkit/types/SizeType.hpp>
+#include <hyprtoolkit/types/FontTypes.hpp>
+#include <hyprtoolkit/core/Input.hpp>
+
+#include "../helpers/SmartPtrAdapter.hpp"
+
+using namespace Hyprutils::Math;
+using namespace Hyprutils::Memory;
+
+namespace Hyprtoolkit::Lua {
+
+void registerVector2D(sol::state& lua) {
+    lua.new_usertype<Vector2D>("Vector2D",
+        sol::constructors<Vector2D(), Vector2D(double, double)>(),
+        "x", &Vector2D::x,
+        "y", &Vector2D::y,
+        "floor", &Vector2D::floor,
+        "round", &Vector2D::round,
+        "clamp", &Vector2D::clamp,
+        "distance", &Vector2D::distance,
+        sol::meta_function::addition, static_cast<Vector2D (Vector2D::*)(const Vector2D&) const>(&Vector2D::operator+),
+        sol::meta_function::subtraction, static_cast<Vector2D (Vector2D::*)(const Vector2D&) const>(&Vector2D::operator-),
+        sol::meta_function::multiplication, sol::overload(
+            [](const Vector2D& self, double scalar) { return self * scalar; },
+            static_cast<Vector2D (Vector2D::*)(const Vector2D&) const>(&Vector2D::operator*)
+        ),
+        sol::meta_function::division, [](const Vector2D& self, double scalar) { return self / scalar; },
+        sol::meta_function::equal_to, &Vector2D::operator==,
+        sol::meta_function::to_string, [](const Vector2D& v) {
+            return "Vector2D(" + std::to_string(v.x) + ", " + std::to_string(v.y) + ")";
+        }
+    );
+
+    // Convenience constructor
+    lua["Vector2D"]["new"] = [](double x, double y) { return Vector2D{x, y}; };
+}
+
+void registerBox(sol::state& lua) {
+    lua.new_usertype<CBox>("CBox",
+        sol::constructors<CBox(), CBox(double, double, double, double), CBox(const Vector2D&, const Vector2D&)>(),
+        "x", &CBox::x,
+        "y", &CBox::y,
+        "w", &CBox::w,
+        "h", &CBox::h,
+        "pos", &CBox::pos,
+        "size", &CBox::size,
+        "middle", &CBox::middle,
+        "containsPoint", &CBox::containsPoint,
+        "empty", &CBox::empty,
+        "intersection", &CBox::intersection,
+        "expand", [](CBox& self, double d) -> CBox& { return self.expand(d); },
+        "round", &CBox::round,
+        "translate", &CBox::translate,
+        "scale", sol::overload(
+            [](CBox& self, double d) -> CBox& { return self.scale(d); },
+            static_cast<CBox& (CBox::*)(const Vector2D&)>(&CBox::scale)
+        )
+    );
+
+    lua["CBox"]["new"] = [](double x, double y, double w, double h) { return CBox{x, y, w, h}; };
+}
+
+void registerColor(sol::state& lua) {
+    lua.new_usertype<CHyprColor>("CHyprColor",
+        sol::constructors<
+            CHyprColor(),
+            CHyprColor(float, float, float, float),
+            CHyprColor(uint64_t)
+        >(),
+        "r", &CHyprColor::r,
+        "g", &CHyprColor::g,
+        "b", &CHyprColor::b,
+        "a", &CHyprColor::a,
+        "getAsHex", &CHyprColor::getAsHex,
+        "brighten", &CHyprColor::brighten,
+        "darken", &CHyprColor::darken,
+        "mix", &CHyprColor::mix,
+        "stripA", &CHyprColor::stripA,
+        sol::meta_function::equal_to, &CHyprColor::operator==,
+        sol::meta_function::to_string, [](const CHyprColor& c) {
+            return "CHyprColor(" + std::to_string(c.r) + ", " + std::to_string(c.g) + ", " +
+                   std::to_string(c.b) + ", " + std::to_string(c.a) + ")";
+        }
+    );
+
+    // Convenience constructors
+    lua["CHyprColor"]["new"] = sol::overload(
+        [](float r, float g, float b) { return CHyprColor(r, g, b, 1.0f); },
+        [](float r, float g, float b, float a) { return CHyprColor(r, g, b, a); }
+    );
+    lua["CHyprColor"]["fromHex"] = [](uint64_t hex) { return CHyprColor(hex); };
+}
+
+void registerDynamicSize(sol::state& lua) {
+    // Sizing type enum
+    lua.new_enum<CDynamicSize::eSizingType>("SizingType",
+        {
+            {"ABSOLUTE", CDynamicSize::HT_SIZE_ABSOLUTE},
+            {"PERCENT", CDynamicSize::HT_SIZE_PERCENT},
+            {"AUTO", CDynamicSize::HT_SIZE_AUTO}
+        }
+    );
+
+    lua.new_usertype<CDynamicSize>("CDynamicSize",
+        sol::constructors<CDynamicSize(CDynamicSize::eSizingType, CDynamicSize::eSizingType, const Vector2D&)>(),
+        "calculate", &CDynamicSize::calculate,
+        // Enum values accessible via CDynamicSize.HT_SIZE_*
+        "HT_SIZE_ABSOLUTE", sol::var(CDynamicSize::HT_SIZE_ABSOLUTE),
+        "HT_SIZE_PERCENT", sol::var(CDynamicSize::HT_SIZE_PERCENT),
+        "HT_SIZE_AUTO", sol::var(CDynamicSize::HT_SIZE_AUTO)
+    );
+
+    // Convenience table for creating sizes
+    lua["DynamicSize"] = lua.create_table_with(
+        "absolute", [](double w, double h) {
+            return CDynamicSize(CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {w, h});
+        },
+        "percent", [](double w, double h) {
+            return CDynamicSize(CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {w, h});
+        },
+        "auto_", []() {
+            return CDynamicSize(CDynamicSize::HT_SIZE_AUTO, CDynamicSize::HT_SIZE_AUTO, {0, 0});
+        },
+        "mixed", [](CDynamicSize::eSizingType typeX, CDynamicSize::eSizingType typeY, double w, double h) {
+            return CDynamicSize(typeX, typeY, {w, h});
+        }
+    );
+}
+
+void registerFontTypes(sol::state& lua) {
+    // Font sizing base enum
+    lua.new_enum<CFontSize::eSizingBase>("FontSizeBase",
+        {
+            {"H1", CFontSize::HT_FONT_H1},
+            {"H2", CFontSize::HT_FONT_H2},
+            {"H3", CFontSize::HT_FONT_H3},
+            {"TEXT", CFontSize::HT_FONT_TEXT},
+            {"SMALL", CFontSize::HT_FONT_SMALL},
+            {"ABSOLUTE", CFontSize::HT_FONT_ABSOLUTE}
+        }
+    );
+
+    lua.new_usertype<CFontSize>("CFontSize",
+        sol::constructors<CFontSize(CFontSize::eSizingBase, float)>(),
+        "ptSize", &CFontSize::ptSize,
+        // Enum values accessible via CFontSize.HT_FONT_*
+        "HT_FONT_H1", sol::var(CFontSize::HT_FONT_H1),
+        "HT_FONT_H2", sol::var(CFontSize::HT_FONT_H2),
+        "HT_FONT_H3", sol::var(CFontSize::HT_FONT_H3),
+        "HT_FONT_TEXT", sol::var(CFontSize::HT_FONT_TEXT),
+        "HT_FONT_SMALL", sol::var(CFontSize::HT_FONT_SMALL),
+        "HT_FONT_ABSOLUTE", sol::var(CFontSize::HT_FONT_ABSOLUTE)
+    );
+
+    // Font alignment enum
+    lua.new_enum<eFontAlignment>("FontAlignment",
+        {
+            {"LEFT", HT_FONT_ALIGN_LEFT},
+            {"CENTER", HT_FONT_ALIGN_CENTER},
+            {"RIGHT", HT_FONT_ALIGN_RIGHT}
+        }
+    );
+
+    // Convenience table for creating font sizes
+    lua["FontSize"] = lua.create_table_with(
+        "h1", [](float mult) { return CFontSize(CFontSize::HT_FONT_H1, mult); },
+        "h2", [](float mult) { return CFontSize(CFontSize::HT_FONT_H2, mult); },
+        "h3", [](float mult) { return CFontSize(CFontSize::HT_FONT_H3, mult); },
+        "text", [](float mult) { return CFontSize(CFontSize::HT_FONT_TEXT, mult); },
+        "small", [](float mult) { return CFontSize(CFontSize::HT_FONT_SMALL, mult); },
+        "absolute", [](float size) { return CFontSize(CFontSize::HT_FONT_ABSOLUTE, size); }
+    );
+
+    // Default versions (multiplier = 1)
+    lua["FontSize"]["H1"] = CFontSize(CFontSize::HT_FONT_H1, 1.0f);
+    lua["FontSize"]["H2"] = CFontSize(CFontSize::HT_FONT_H2, 1.0f);
+    lua["FontSize"]["H3"] = CFontSize(CFontSize::HT_FONT_H3, 1.0f);
+    lua["FontSize"]["TEXT"] = CFontSize(CFontSize::HT_FONT_TEXT, 1.0f);
+    lua["FontSize"]["SMALL"] = CFontSize(CFontSize::HT_FONT_SMALL, 1.0f);
+}
+
+void registerInputTypes(sol::state& lua) {
+    // Mouse button enum
+    lua.new_enum<Input::eMouseButton>("MouseButton",
+        {
+            {"UNKNOWN", Input::MOUSE_BUTTON_UNKNOWN},
+            {"LEFT", Input::MOUSE_BUTTON_LEFT},
+            {"RIGHT", Input::MOUSE_BUTTON_RIGHT},
+            {"MIDDLE", Input::MOUSE_BUTTON_MIDDLE}
+        }
+    );
+
+    // Axis enum
+    lua.new_enum<Input::eAxisAxis>("AxisAxis",
+        {
+            {"HORIZONTAL", Input::AXIS_AXIS_HORIZONTAL},
+            {"VERTICAL", Input::AXIS_AXIS_VERTICAL}
+        }
+    );
+
+    // Keyboard modifiers enum
+    lua.new_enum<Input::eKeyboardModifier>("KeyboardModifier",
+        {
+            {"SHIFT", Input::HT_MODIFIER_SHIFT},
+            {"CAPS", Input::HT_MODIFIER_CAPS},
+            {"CTRL", Input::HT_MODIFIER_CTRL},
+            {"ALT", Input::HT_MODIFIER_ALT},
+            {"MOD2", Input::HT_MODIFIER_MOD2},
+            {"MOD3", Input::HT_MODIFIER_MOD3},
+            {"META", Input::HT_MODIFIER_META},
+            {"MOD5", Input::HT_MODIFIER_MOD5}
+        }
+    );
+
+    // Keyboard key event struct
+    lua.new_usertype<Input::SKeyboardKeyEvent>("KeyboardKeyEvent",
+        sol::no_constructor,
+        "xkbKeysym", &Input::SKeyboardKeyEvent::xkbKeysym,
+        "down", &Input::SKeyboardKeyEvent::down,
+        "repeat", &Input::SKeyboardKeyEvent::repeat,
+        "utf8", &Input::SKeyboardKeyEvent::utf8,
+        "modMask", &Input::SKeyboardKeyEvent::modMask,
+        // Helper to check for modifiers
+        "hasModifier", [](const Input::SKeyboardKeyEvent& e, Input::eKeyboardModifier mod) {
+            return (e.modMask & static_cast<uint32_t>(mod)) != 0;
+        }
+    );
+}
+
+void registerPalette(sol::state& lua) {
+    // CPalette with direct access to color/var fields via lambdas
+    // (anonymous structs don't work well with sol2's usertype system)
+    lua.new_usertype<CPalette>("CPalette",
+        sol::no_constructor,
+        "palette", &CPalette::palette,
+        "emptyPalette", &CPalette::emptyPalette,
+        // Color accessors
+        "background", sol::property([](CPalette& p) { return p.m_colors.background; }),
+        "text", sol::property([](CPalette& p) { return p.m_colors.text; }),
+        "base", sol::property([](CPalette& p) { return p.m_colors.base; }),
+        "alternateBase", sol::property([](CPalette& p) { return p.m_colors.alternateBase; }),
+        "brightText", sol::property([](CPalette& p) { return p.m_colors.brightText; }),
+        "accent", sol::property([](CPalette& p) { return p.m_colors.accent; }),
+        "accentSecondary", sol::property([](CPalette& p) { return p.m_colors.accentSecondary; }),
+        // Vars accessors
+        "h1Size", sol::property([](CPalette& p) { return p.m_vars.h1Size; }),
+        "h2Size", sol::property([](CPalette& p) { return p.m_vars.h2Size; }),
+        "h3Size", sol::property([](CPalette& p) { return p.m_vars.h3Size; }),
+        "fontSize", sol::property([](CPalette& p) { return p.m_vars.fontSize; }),
+        "smallFontSize", sol::property([](CPalette& p) { return p.m_vars.smallFontSize; }),
+        "iconTheme", sol::property([](CPalette& p) { return p.m_vars.iconTheme; }),
+        "bigRounding", sol::property([](CPalette& p) { return p.m_vars.bigRounding; }),
+        "smallRounding", sol::property([](CPalette& p) { return p.m_vars.smallRounding; }),
+        "fontFamily", sol::property([](CPalette& p) { return p.m_vars.fontFamily; }),
+        "fontFamilyMonospace", sol::property([](CPalette& p) { return p.m_vars.fontFamilyMonospace; })
+    );
+}
+
+// Main registration function for all types
+void registerTypes(sol::state& lua) {
+    registerVector2D(lua);
+    registerBox(lua);
+    registerColor(lua);
+    registerDynamicSize(lua);
+    registerFontTypes(lua);
+    registerInputTypes(lua);
+    registerPalette(lua);
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/bindings/Window.cpp
+++ b/src/bindings/lua/bindings/Window.cpp
@@ -1,0 +1,120 @@
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprtoolkit/window/Window.hpp>
+#include <hyprtoolkit/element/Element.hpp>
+#include <hyprtoolkit/core/Output.hpp>
+
+#include "../helpers/SmartPtrAdapter.hpp"
+#include "../helpers/CallbackAdapter.hpp"
+
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::Math;
+
+namespace Hyprtoolkit::Lua {
+
+void registerWindow(sol::state& lua) {
+    // Window type enum
+    lua.new_enum<eWindowType>("WindowType",
+        {
+            {"TOPLEVEL", HT_WINDOW_TOPLEVEL},
+            {"POPUP", HT_WINDOW_POPUP},
+            {"LAYER", HT_WINDOW_LAYER},
+            {"LOCK_SURFACE", HT_WINDOW_LOCK_SURFACE}
+        }
+    );
+
+    // Window builder
+    lua.new_usertype<CWindowBuilder>("CWindowBuilder",
+        sol::no_constructor,
+        "begin", &CWindowBuilder::begin,
+        "type", &CWindowBuilder::type,
+        "appTitle", [](CSharedPointer<CWindowBuilder> self, const std::string& t) {
+            return self->appTitle(std::string(t));
+        },
+        "appClass", [](CSharedPointer<CWindowBuilder> self, const std::string& c) {
+            return self->appClass(std::string(c));
+        },
+        "preferredSize", &CWindowBuilder::preferredSize,
+        "minSize", &CWindowBuilder::minSize,
+        "maxSize", &CWindowBuilder::maxSize,
+
+        // Layer and lock surface options
+        "prefferedOutput", &CWindowBuilder::prefferedOutput,
+        "marginTopLeft", &CWindowBuilder::marginTopLeft,
+        "marginBottomRight", &CWindowBuilder::marginBottomRight,
+        "layer", &CWindowBuilder::layer,
+        "anchor", &CWindowBuilder::anchor,
+        "exclusiveEdge", &CWindowBuilder::exclusiveEdge,
+        "exclusiveZone", &CWindowBuilder::exclusiveZone,
+        "kbInteractive", &CWindowBuilder::kbInteractive,
+
+        // Popup options
+        "parent", &CWindowBuilder::parent,
+        "pos", &CWindowBuilder::pos,
+
+        "commence", &CWindowBuilder::commence
+    );
+
+    // IWindow interface
+    lua.new_usertype<IWindow>("IWindow",
+        sol::no_constructor,
+        "pixelSize", &IWindow::pixelSize,
+        "scale", &IWindow::scale,
+        "close", &IWindow::close,
+        "open", &IWindow::open,
+        "cursorPos", &IWindow::cursorPos,
+        "m_rootElement", &IWindow::m_rootElement,
+
+        // Event listeners - we expose them as methods that accept callbacks
+        "onResized", [](IWindow* self, sol::function fn) {
+            self->m_events.resized.listenStatic([fn](Vector2D size) {
+                sol::protected_function_result result = fn(size);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Window resized callback error: %s\n", err.what());
+                }
+            });
+        },
+        "onCloseRequest", [](IWindow* self, sol::function fn) {
+            self->m_events.closeRequest.listenStatic([fn]() {
+                sol::protected_function_result result = fn();
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Window closeRequest callback error: %s\n", err.what());
+                }
+            });
+        },
+        "onPopupClosed", [](IWindow* self, sol::function fn) {
+            self->m_events.popupClosed.listenStatic([fn]() {
+                sol::protected_function_result result = fn();
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Window popupClosed callback error: %s\n", err.what());
+                }
+            });
+        },
+        "onLayerClosed", [](IWindow* self, sol::function fn) {
+            self->m_events.layerClosed.listenStatic([fn]() {
+                sol::protected_function_result result = fn();
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Window layerClosed callback error: %s\n", err.what());
+                }
+            });
+        },
+        "onKeyboardKey", [](IWindow* self, sol::function fn) {
+            self->m_events.keyboardKey.listenStatic([fn](Input::SKeyboardKeyEvent event) {
+                sol::protected_function_result result = fn(event);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    fprintf(stderr, "[Lua] Window keyboardKey callback error: %s\n", err.what());
+                }
+            });
+        }
+    );
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/helpers/CallbackAdapter.hpp
+++ b/src/bindings/lua/helpers/CallbackAdapter.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <functional>
+#include <string>
+
+namespace Hyprtoolkit::Lua {
+
+// Convert a Lua function to a std::function with error handling
+template <typename Ret, typename... Args>
+std::function<Ret(Args...)> luaToCallback(sol::protected_function fn) {
+    return [fn](Args... args) -> Ret {
+        sol::protected_function_result result = fn(args...);
+        if (!result.valid()) {
+            sol::error err = result;
+            // TODO: integrate with hyprtoolkit logging
+            fprintf(stderr, "[Lua] Callback error: %s\n", err.what());
+            if constexpr (!std::is_void_v<Ret>) {
+                return Ret{};
+            }
+        } else {
+            if constexpr (!std::is_void_v<Ret>) {
+                return result.get<Ret>();
+            }
+        }
+    };
+}
+
+// Specialization for void return type
+template <typename... Args>
+std::function<void(Args...)> luaToVoidCallback(sol::protected_function fn) {
+    return [fn](Args... args) {
+        sol::protected_function_result result = fn(args...);
+        if (!result.valid()) {
+            sol::error err = result;
+            fprintf(stderr, "[Lua] Callback error: %s\n", err.what());
+        }
+    };
+}
+
+// Safe callback wrapper that captures the Lua function
+template <typename... Args>
+auto makeSafeCallback(sol::function fn) {
+    return [fn](Args... args) {
+        sol::protected_function pfn = fn;
+        sol::protected_function_result result = pfn(args...);
+        if (!result.valid()) {
+            sol::error err = result;
+            fprintf(stderr, "[Lua] Callback error: %s\n", err.what());
+        }
+    };
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/helpers/ColorFnAdapter.hpp
+++ b/src/bindings/lua/helpers/ColorFnAdapter.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprtoolkit/palette/Color.hpp>
+#include <functional>
+
+namespace Hyprtoolkit::Lua {
+
+using colorFn = std::function<CHyprColor()>;
+
+// Convert a Lua object (either a CHyprColor or a function) to colorFn
+inline colorFn luaToColorFn(sol::object obj) {
+    if (obj.is<CHyprColor>()) {
+        // Static color - capture by value
+        CHyprColor color = obj.as<CHyprColor>();
+        return [color]() { return color; };
+    } else if (obj.is<sol::function>()) {
+        // Dynamic color function
+        sol::protected_function fn = obj.as<sol::function>();
+        return [fn]() -> CHyprColor {
+            sol::protected_function_result result = fn();
+            if (result.valid()) {
+                return result.get<CHyprColor>();
+            }
+            // Return black on error
+            fprintf(stderr, "[Lua] colorFn error: %s\n", sol::error(result).what());
+            return CHyprColor(0.0, 0.0, 0.0, 1.0);
+        };
+    }
+    // Default to black
+    return []() { return CHyprColor(0.0, 0.0, 0.0, 1.0); };
+}
+
+// Convert a Lua object to an optional colorFn (returns nullopt if nil)
+inline std::optional<colorFn> luaToOptionalColorFn(sol::object obj) {
+    if (obj.is<sol::nil_t>() || !obj.valid()) {
+        return std::nullopt;
+    }
+    return luaToColorFn(obj);
+}
+
+} // namespace Hyprtoolkit::Lua
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/src/bindings/lua/helpers/SmartPtrAdapter.hpp
+++ b/src/bindings/lua/helpers/SmartPtrAdapter.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include <sol/sol.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <hyprutils/memory/WeakPtr.hpp>
+#include <hyprutils/memory/Atomic.hpp>
+
+namespace sol {
+
+// Tell sol3 that CSharedPointer is a smart pointer
+template <typename T>
+struct unique_usertype_traits<Hyprutils::Memory::CSharedPointer<T>> {
+    using type        = T;
+    using actual_type = Hyprutils::Memory::CSharedPointer<T>;
+
+    static const bool value = true;
+
+    static bool is_null(const actual_type& ptr) {
+        return !ptr;
+    }
+
+    static type* get(const actual_type& ptr) {
+        return ptr.get();
+    }
+};
+
+// Tell sol3 that CWeakPointer is a smart pointer (will auto-lock)
+template <typename T>
+struct unique_usertype_traits<Hyprutils::Memory::CWeakPointer<T>> {
+    using type        = T;
+    using actual_type = Hyprutils::Memory::CWeakPointer<T>;
+
+    static const bool value = true;
+
+    static bool is_null(const actual_type& ptr) {
+        return ptr.expired();
+    }
+
+    static type* get(const actual_type& ptr) {
+        auto locked = ptr.lock();
+        return locked ? locked.get() : nullptr;
+    }
+};
+
+// Tell sol3 that CAtomicSharedPointer is a smart pointer
+template <typename T>
+struct unique_usertype_traits<Hyprutils::Memory::CAtomicSharedPointer<T>> {
+    using type        = T;
+    using actual_type = Hyprutils::Memory::CAtomicSharedPointer<T>;
+
+    static const bool value = true;
+
+    static bool is_null(const actual_type& ptr) {
+        return !ptr;
+    }
+
+    static type* get(const actual_type& ptr) {
+        return ptr.get();
+    }
+};
+
+} // namespace sol
+
+#endif // HYPRTOOLKIT_LUA_ENABLED

--- a/tests/LuaRunner.cpp
+++ b/tests/LuaRunner.cpp
@@ -1,0 +1,33 @@
+#ifdef HYPRTOOLKIT_LUA_ENABLED
+
+#include "bindings/lua/LuaBindings.hpp"
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <script.lua>" << std::endl;
+        return 1;
+    }
+
+    auto luaState = Hyprtoolkit::Lua::createLuaState();
+
+    auto result = luaState->doFile(argv[1]);
+    if (!result.valid()) {
+        sol::error err = result;
+        std::cerr << "Lua error: " << err.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
+
+#else
+
+#include <iostream>
+
+int main() {
+    std::cerr << "Lua support not enabled. Rebuild with -DHYPRTOOLKIT_WITH_LUA=ON" << std::endl;
+    return 1;
+}
+
+#endif


### PR DESCRIPTION
I've shared it yesterday on discord, thought I'd make a PR for it too.

- Added optional lua(flag is -DHYPRTOOLKIT_WITH_LUA=ON) bindings with an example

Can be ran with ./build/hyprtoolkit-lua examples/lua/simple_form.lua

<img width="937" height="764" alt="image" src="https://github.com/user-attachments/assets/ab9b1a87-b271-4e8e-8625-059f92d0b979" />
