### PR TITLE
backend: call destroy on destructor

### DIFF
--- a/src/core/Backend.cpp
+++ b/src/core/Backend.cpp
@@ -173,6 +173,9 @@ void CBackend::addIdle(const std::function<void()>& fn) {
 }
 
 void CBackend::terminate() {
+    if (m_terminate)
+        return;
+
     m_terminate = true;
 
     if (m_sLoopState.eventLoopMutex.try_lock()) {


### PR DESCRIPTION
call destroy on backend destructor to set m_terminate for threads.