### PR TITLE
feat(icons): search for icon themes in $xdg_data_dirs, $xdg_data_home, and ~/.icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ CMakeUserPresets.json
 #cmake-build-*
 
 build/
+result
 .vscode/
 .cache/
 


### PR DESCRIPTION
This changeset replaces the statically declared icon theme paths with a list built by inspecting the XDG Data directories, `XDG_DATA_DIRS` and `XDG_DATA_HOME`, for icons and defaulting to `/usr/local/share/icons` and `/usr/share/icons` if the relevant XDG environment variables are undeclared. It will also search for icons in the non-XDG compliant `~/.icons` directory to preserve existing function.

The motivation for this change is to allow `hyprtoolkit` to search for icon themes in non-FHS compliant distributions (e.g. NixOS) more easily. For example, NixOS does not use `/usr/share` or `/usr/local/share` directories. Instead, it sets `XDG_DATA_DIRS` to include `/run/current-system/sw/share`. I wrote this so I didn't have to wrap the existing nix derivation in a `buildFHSEnv` or author a patch.

- Built and tested locally
- Please forgive my C++. I am very rusty :bow: 