### PR TITLE
image: check if window is valid weak ptr

### DIFF
--- a/src/element/image/Image.cpp
+++ b/src/element/image/Image.cpp
@@ -147,7 +147,9 @@ void SImageImpl::postImageScheduleRecalc() {
         if (cacheEntry)
             size = cacheEntry->tex()->size();
         self->impl->damageEntire();
-        self->impl->window->scheduleReposition(self);
+
+        if (self->impl->window)
+            self->impl->window->scheduleReposition(self);
     }
 }
 


### PR DESCRIPTION
hyprlauncher coredumps here otherwise.

```
#0  0x00007f0575549152 in Hyprtoolkit::SImageImpl::postImageScheduleRecalc (this=0x561d354e3d70) at /var/tmp/portage/gui-libs/hyprtoolkit-9999/work/hyprtoolkit-9999/src/element/image/Image.cpp:150
#1  0x00007f05755a5632 in Hyprtoolkit::CImageElement::renderTex (this=0x561d3530d510) at /var/tmp/portage/gui-libs/hyprtoolkit-9999/work/hyprtoolkit-9999/src/element/image/Image.cpp:76
#2  0x00007f05755a59b3 in Hyprtoolkit::CImageElement::replaceData (this=0x561d3530d510, data=...) at /var/tmp/portage/gui-libs/hyprtoolkit-9999/work/hyprtoolkit-9999/src/element/image/Image.cpp:172
#3  0x00007f057559f276 in Hyprtoolkit::CImageBuilder::commence (this=0x561d35529be0) at /var/tmp/portage/gui-libs/hyprtoolkit-9999/work/hyprtoolkit-9999/src/element/image/Builder.cpp:49
#4  0x0000561d0b55fb43 in CResultButton::setLabel (this=0x561d354e25e0, x="OBS Studio", icon=<optimized out>) at /var/tmp/portage/gui-apps/hyprlauncher-9999/work/hyprlauncher-9999/src/ui/ResultButton.cpp:82
#5  0x0000561d0b5598f2 in CUI::updateResults (this=0x561d322ebdb0, results=<optimized out>) at /var/tmp/portage/gui-apps/hyprlauncher-9999/work/hyprlauncher-9999/src/ui/UI.cpp:172
#6  operator() (__closure=<optimized out>) at /var/tmp/portage/gui-apps/hyprlauncher-9999/work/hyprlauncher-9999/src/query/QueryProcessor.cpp:112
#7  std::__invoke_impl<void, CQueryProcessor::process()::<lambda()>&> (__f=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63
#8  std::__invoke_r<void, CQueryProcessor::process()::<lambda()>&> (__fn=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:113
#9  std::_Function_handler<void(), CQueryProcessor::process()::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
#10 0x00007f0575575fbb in std::function<void()>::operator() (this=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593
#11 Hyprtoolkit::CBackend::enterLoop (this=0x561d34b556e0) at /var/tmp/portage/gui-libs/hyprtoolkit-9999/work/hyprtoolkit-9999/src/core/Backend.cpp:435
#12 0x0000561d0b52ddb4 in main (argc=<optimized out>, argv=<optimized out>, envp=<optimized out>) at /var/tmp/portage/gui-apps/hyprlauncher-9999/work/hyprlauncher-9999/src/main.cpp:127
````

seems like thats appropiate? a bit below its done just like that in `void CImageElement::replaceData(const SImageData& data)`