### PR TITLE
Fix to build with rawhide g++.

### DIFF
--- a/src/palette/ConfigManager.cpp
+++ b/src/palette/ConfigManager.cpp
@@ -8,6 +8,7 @@
 #include <glob.h>
 #include <filesystem>
 #include <cstring>
+#include <climits>
 
 using namespace Hyprtoolkit;
 


### PR DESCRIPTION
0.5.3 fails to build from source with NAME_MAX undefined.
The following patch fixes this.
