### PR TITLE
element/image: error when image exceeds max resolution

### DIFF
--- a/src/element/image/Image.cpp
+++ b/src/element/image/Image.cpp
@@ -129,7 +129,13 @@ void SImageImpl::postImageLoad() {
     if (resource->m_asset.cairoSurface) {
         ASP<IAsyncResource> resourceGeneric(resource);
         size = resource->m_asset.pixelSize;
-        cacheEntry->texDone(g_renderer->uploadTexture({.resource = resourceGeneric, .fitMode = data.fitMode}));
+
+        const auto MAX_SIZE = g_renderer->getMaxTextureSize();
+        if (size.x > MAX_SIZE || size.y > MAX_SIZE) {
+            failed = true;
+            g_logger->log(HT_LOG_ERROR, "Image: failed loading, image dimensions {}x{} exceed max texture size {}", (int)size.x, (int)size.y, MAX_SIZE);
+        } else
+            cacheEntry->texDone(g_renderer->uploadTexture({.resource = resourceGeneric, .fitMode = data.fitMode}));
     } else {
         failed = true;
         g_logger->log(HT_LOG_ERROR, "Image: failed loading, hyprgraphics couldn't load asset {}", lastPath);

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -76,6 +76,8 @@ namespace Hyprtoolkit {
         virtual SP<CSyncTimeline>    exportSync(SP<Aquamarine::IBuffer> buf) = 0;
 
         virtual bool                 explicitSyncSupported() = 0;
+
+        virtual int                  getMaxTextureSize() = 0;
     };
 
     inline SP<IRenderer> g_renderer;

--- a/src/renderer/gl/OpenGL.cpp
+++ b/src/renderer/gl/OpenGL.cpp
@@ -430,6 +430,9 @@ COpenGLRenderer::COpenGLRenderer(int drmFD) : m_drmFD(drmFD) {
 
     RASSERT(success, "EGL does not support KHR_platform_gbm or EXT_platform_device, this is an issue with your gpu driver.");
 
+    makeEGLCurrent();
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, cc<GLint*>(&m_maxTextureSize));
+
     auto* const EXTENSIONS = rc<const char*>(glGetString(GL_EXTENSIONS));
     RASSERT(EXTENSIONS, "Couldn't retrieve openGL extensions!");
 
@@ -536,6 +539,10 @@ COpenGLRenderer::~COpenGLRenderer() {
 
 bool COpenGLRenderer::explicitSyncSupported() {
     return !Env::envEnabled("HT_NO_EXPLICIT_SYNC") && m_syncobjSupported && m_exts.EGL_ANDROID_native_fence_sync_ext;
+}
+
+int COpenGLRenderer::getMaxTextureSize() {
+    return m_maxTextureSize;
 }
 
 CBox COpenGLRenderer::logicalToGL(const CBox& box, bool transform) {

--- a/src/renderer/gl/OpenGL.hpp
+++ b/src/renderer/gl/OpenGL.hpp
@@ -10,6 +10,7 @@
 #include <hyprutils/os/FileDescriptor.hpp>
 #include <aquamarine/buffer/Buffer.hpp>
 
+#include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -42,6 +43,8 @@ namespace Hyprtoolkit {
 
         virtual bool                 explicitSyncSupported();
 
+        virtual int                  getMaxTextureSize();
+
       private:
         CBox                           logicalToGL(const CBox& box, bool transform = true);
         CRegion                        damageWithClip();
@@ -66,6 +69,7 @@ namespace Hyprtoolkit {
         bool                           m_hasModifiers     = true;
         int                            m_drmFD            = -1;
         bool                           m_syncobjSupported = false;
+        const GLint                    m_maxTextureSize   = 0;
 
         struct {
             PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC glEGLImageTargetRenderbufferStorageOES = nullptr;


### PR DESCRIPTION
After updating hyprpaper to 0.8.1 my background stopped showing, but the program would run without any errors. I download full resolution art scans from artsandculture.google.com resulting in 135mb 22413x15124 images, just because I can. 

In the pre 0.8 version something probably downscaled it as the GL_MAX_TEXTURE_SIZE is way, way below this resolution. Just in case more people do silly things like me it would be great to have an error message.

```
[..]
DEBUG ]: DRM syncobj timeline support: yes
DEBUG ]: Found 1 output(s)
DEBUG ]: wayland: configure layer with 2560x1440
ERR ]: Image: failed loading, image dimensions 22413x15124 exceed max texture size 16384
DEBUG ]: layer: got fractional scale: 100.0%
```

I have never touched a c++ project so this was mostly written by Claude. Let me know if this is the wrong place / way / project etc.