### PR TITLE
fix: undefined behavior in cover and tile mode causing horizontal pixels

### DIFF
--- a/src/renderer/gl/OpenGL.cpp
+++ b/src/renderer/gl/OpenGL.cpp
@@ -896,17 +896,18 @@ void COpenGLRenderer::renderTexture(const STextureRenderData& data) {
     glUniform1i(shader->discardAlpha, 0);
     glUniform1i(shader->applyTint, 0);
 
+    std::array<float, 8> texVerts;
     if (data.texture->fitMode() == IMAGE_FIT_MODE_STRETCH || data.texture->fitMode() == IMAGE_FIT_MODE_CONTAIN) {
         glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
         glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
     } else if (data.texture->fitMode() == IMAGE_FIT_MODE_COVER) {
-        const auto VERTS = coverImage(data.box, tex->m_size);
+        texVerts = coverImage(data.box, tex->m_size);
         glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
-        glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, VERTS.data());
+        glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, texVerts.data());
     } else if (data.texture->fitMode() == IMAGE_FIT_MODE_TILE) {
-        const auto VERTS = tileImage(data.box, tex->m_size);
+        texVerts = tileImage(data.box, tex->m_size);
         glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
-        glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, VERTS.data());
+        glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, texVerts.data());
         glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_S, GL_REPEAT);
         glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_T, GL_REPEAT);
     }


### PR DESCRIPTION
On my Gentoo Linux system with Clang 21.1.8, hyprpaper 0.5.3 rendered my background as horizontal stripes of pixels in cover mode. My LLM vibe-coded this simple fix for me. The conversation:

> Summary
Bug found and fixed in hyprtoolkit (not hyprpaper).
>
> Root Cause
> In OpenGL.cpp:899-913, the VERTS array returned by coverImage() was declared inside the if block, causing it to go out of scope before glDrawArrays() was called at line 920. The pointer passed to glVertexAttribPointer became dangling, causing undefined behavior (horizontal stripes).
>
> Fix
> Moved the texVerts declaration outside the conditional blocks so it remains in scope until after glDrawArrays