### PR TITLE
TextBox: Fix carriage returns not respecting multiline=false

### DIFF
--- a/src/element/textbox/Textbox.cpp
+++ b/src/element/textbox/Textbox.cpp
@@ -324,7 +324,7 @@ void CTextboxElement::init() {
         if (ev.utf8.empty())
             return;
 
-        if (ev.utf8 == "\n" && !m_impl->data.multiline)
+        if ((ev.utf8 == "\n" || ev.utf8 == "\r") && !m_impl->data.multiline)
             return;
 
         m_impl->removeSelectedText();

--- a/tests/unit/elements/Textbox.cpp
+++ b/tests/unit/elements/Textbox.cpp
@@ -77,3 +77,21 @@ TEST(Element, textboxEditing) {
 
     textbox.reset();
 }
+
+TEST(Element, textBoxNewLines) {
+    Tests::Tricks::createBackendSupport();
+
+    auto textbox = CTextboxBuilder::begin()->defaultText("I am on the first line!")->multiline(true)->commence();
+    textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.xkbKeysym = XKB_KEY_End});
+    textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.utf8 = "\r"});
+    textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.utf8 = "\n"});
+    EXPECT_EQ(textbox->currentText(), "I am on the first line!\r\n");
+    textbox.reset();
+
+    textbox = CTextboxBuilder::begin()->defaultText("I am on the first line!")->multiline(false)->commence();
+    textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.xkbKeysym = XKB_KEY_End});
+    textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.utf8 = "\r"});
+    textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.utf8 = "\n"});
+    EXPECT_EQ(textbox->currentText(), "I am on the first line!");
+    textbox.reset();
+}


### PR DESCRIPTION
**Describe your PR, what does it fix/add?**
Fixes a small irk that textboxes will still newline when configured with `tb->multiline(false)` and when fed with a carriage return `\r`.

**Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)**
No

**Is it ready for merging, or does it need work?**
Should be ready