### PR TITLE
element/text: attach async completion listener before enqueueing

### DIFF
--- a/src/element/text/Text.cpp
+++ b/src/element/text/Text.cpp
@@ -377,9 +377,8 @@ void STextImpl::renderTex() {
 
     ASP<IAsyncResource> resourceGeneric(resource);
 
-    g_asyncResourceGatherer->enqueue(resourceGeneric);
-
     if (!data.async) {
+        g_asyncResourceGatherer->enqueue(resourceGeneric);
         g_asyncResourceGatherer->await(resourceGeneric);
         postTexLoad();
     } else {
@@ -394,6 +393,8 @@ void STextImpl::renderTex() {
                 postTexLoad();
             });
         });
+
+        g_asyncResourceGatherer->enqueue(resourceGeneric);
     }
 }
 


### PR DESCRIPTION
This PR is in response to an issue I found in hyprlauncher. https://github.com/hyprwm/hyprlauncher/issues/134

Under heavy CPU load / less predictable scheduling, there is an issue with the order of the enqueue and the listener registration. It can happen that the postTexLoad() function never executes, which will leave the text objcet in a bad state.

I was able to test confirm that this change fixes the issue mentioned above.

```
    ASP<IAsyncResource> resourceGeneric(resource);

    g_asyncResourceGatherer->enqueue(resourceGeneric); // move below listener attachment

    if (!data.async) {
// move enqueue here for consistency
        g_asyncResourceGatherer->await(resourceGeneric);
        postTexLoad();
    } else {
        resource->m_events.finished.listenStatic([this, self = self->impl->self] {
            if (!self)
                return;

            g_backend->addIdle([this, self = self]() {
                if (!self)
                    return;

                postTexLoad();
            });
        });
// move enqueue here to guarantee that the listener is attached 
    }
```