### PR TITLE
treewide: shutdown UAF, layout shrink, slider digits, async lifetime

### DIFF
--- a/src/core/AnimatedVariable.hpp
+++ b/src/core/AnimatedVariable.hpp
@@ -38,12 +38,6 @@ namespace Hyprtoolkit {
         static constexpr eAnimatedVarType value = AVARTYPE_COLOR;
     };
 
-    // TODO:
-    // template <>
-    // struct STypeToAnimatedVarType_t<CGradientValueData> {
-    //     static constexpr eAnimatedVarType value = AVARTYPE_GRADIENT;
-    // };
-
     template <class T>
     inline constexpr eAnimatedVarType typeToeAnimatedVarType = STypeToAnimatedVarType_t<T>::value;
 

--- a/src/core/Backend.cpp
+++ b/src/core/Backend.cpp
@@ -225,6 +225,8 @@ void CBackend::terminate() {
         g_asyncResourceGatherer.reset();
         g_animationManager.reset();
 
+        g_iconFactory.reset();
+        g_config.reset();
         g_palette.reset();
         g_backend.reset();
         g_logger.reset();

--- a/src/core/Backend.cpp
+++ b/src/core/Backend.cpp
@@ -60,15 +60,12 @@ CBackend::CBackend() {
 }
 
 CBackend::~CBackend() {
-    destroy();
-
-    g_openGL.reset();
-    g_renderer.reset();
-    g_config.reset();
-    g_palette.reset();
-    g_iconFactory.reset();
-    g_waylandPlatform.reset();
-    g_logger.reset();
+    // ~CBackend may run during static destruction, when other inline globals
+    // (g_renderer, g_openGL, g_logger, ...) may already be destroyed. touching
+    // them here is UB. cleanup of those globals has to happen earlier, see the
+    // atexit handler installed in IBackend::create, so we only release our own
+    // members here.
+    m_terminate = true;
 
     close(m_sLoopState.exitfd[0]);
     close(m_sLoopState.exitfd[1]);
@@ -111,6 +108,16 @@ SP<IBackend> IBackend::create() {
     }
     g_openGL   = makeShared<COpenGLRenderer>(g_waylandPlatform->m_drmState.fd);
     g_renderer = g_openGL;
+
+    // run cleanup while every inline static SP is still alive. by the time
+    // ~CBackend reaches static destruction, sibling globals like g_renderer
+    // may already have been freed, so any cleanup that touches them must run
+    // here. atexit fires after main returns but before static destructors.
+    static const int once = std::atexit([]() {
+        if (g_backend)
+            g_backend->destroy();
+    });
+    (void)once;
 
     return g_backend;
 };

--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -22,7 +22,6 @@ namespace Hyprtoolkit::LinearLayout {
         using CBox     = Hyprutils::Math::CBox;
 
         auto axisPrimary = [](const Vector2D& v) -> double { return Horizontal ? v.x : v.y; };
-        auto axisCross   = [](const Vector2D& v) -> double { return Horizontal ? v.y : v.x; };
         auto boxPrimary  = [](const CBox& b) -> double { return Horizontal ? b.w : b.h; };
         auto grows       = [](const SP<IElement>& e) -> bool { return Horizontal ? e->impl->growH : e->impl->growV; };
 

--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -26,7 +26,7 @@ namespace Hyprtoolkit::LinearLayout {
         auto boxPrimary  = [](const CBox& b) -> double { return Horizontal ? b.w : b.h; };
         auto grows       = [](const SP<IElement>& e) -> bool { return Horizontal ? e->impl->growH : e->impl->growV; };
 
-        const double        MAX = boxPrimary(box);
+        const double        MAX = (double)(uint64_t)boxPrimary(box); // floor to match upstream behavior
         double              used = 0;
 
         std::vector<size_t> sizes;
@@ -58,10 +58,10 @@ namespace Hyprtoolkit::LinearLayout {
                         const auto& prevChild = C.at(j);
                         const auto  MIN       = prevChild->minimumSize(box.size());
                         if (!MIN.has_value()) {
-                            // we can shrink this child to zero
+                            // can shrink to zero. give all of it, continue if not enough.
                             if (needs > sizes.at(j)) {
-                                sizes.at(j) -= needs - sizes.at(j);
-                                needs -= needs - sizes.at(j);
+                                needs -= sizes.at(j);
+                                sizes.at(j) = 0;
                                 continue;
                             }
 
@@ -69,11 +69,11 @@ namespace Hyprtoolkit::LinearLayout {
                             needs = 0;
                             break;
                         } else if (axisPrimary(*MIN) < sizes.at(j)) {
-                            // we can shrink it a bit
+                            // can shrink down to MIN. give all available slack, continue if not enough.
                             const double slack = sizes.at(j) - axisPrimary(*MIN);
                             if (needs > slack) {
-                                sizes.at(j) -= needs - slack;
-                                needs -= needs - slack;
+                                sizes.at(j) -= slack;
+                                needs -= slack;
                                 continue;
                             }
 
@@ -152,7 +152,7 @@ namespace Hyprtoolkit::LinearLayout {
                 g_positioner->position(child, childBox, Vector2D{box.w, childBox.h + (MAX - used)});
             }
 
-            cursor += (size_t)(Horizontal ? childBox.w : childBox.h) + (size_t)gap;
+            cursor += (size_t)((Horizontal ? childBox.w : childBox.h) + gap);
         }
     }
 }

--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "../helpers/Memory.hpp"
+#include "../layout/Positioner.hpp"
+#include "Element.hpp"
+
+#include <hyprutils/math/Box.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace Hyprtoolkit::LinearLayout {
+    // axis-agnostic reposition for row / column layouts. Horizontal=true means
+    // children flow along x (row layout); false means they flow along y (column).
+    // childSize must return the layout's preferred-or-minimum size for a child.
+    template <bool Horizontal>
+    inline void reposition(IElement* self, const Hyprutils::Math::CBox& box, const std::vector<SP<IElement>>& C, float gap, const std::function<Hyprutils::Math::Vector2D(SP<IElement>)>& childSize) {
+        using Vector2D = Hyprutils::Math::Vector2D;
+        using CBox     = Hyprutils::Math::CBox;
+
+        auto axisPrimary = [](const Vector2D& v) -> double { return Horizontal ? v.x : v.y; };
+        auto axisCross   = [](const Vector2D& v) -> double { return Horizontal ? v.y : v.x; };
+        auto boxPrimary  = [](const CBox& b) -> double { return Horizontal ? b.w : b.h; };
+        auto grows       = [](const SP<IElement>& e) -> bool { return Horizontal ? e->impl->growH : e->impl->growV; };
+
+        const double        MAX = boxPrimary(box);
+        double              used = 0;
+
+        std::vector<size_t> sizes;
+        sizes.resize(C.size());
+
+        size_t i = 0;
+        for (i = 0; i < C.size(); ++i) {
+            const auto& child = C.at(i);
+
+            Vector2D    cSize = childSize(child);
+            if (cSize == Vector2D{-1, -1})
+                cSize = Horizontal ? Vector2D{1.F, box.h} : Vector2D{box.w, 1.F};
+
+            if (used + axisPrimary(cSize) > MAX + 1) {
+                // we exceeded our available space.
+                if (!child->minimumSize(box.size())) {
+                    // doesn't fit: disable
+                    child->impl->setFailedPositioning(true);
+                    continue;
+                }
+
+                cSize = *child->minimumSize(box.size());
+
+                if (used + axisPrimary(cSize) > MAX + 1) {
+                    // doesn't fit: try to shrink any previous element if it allows to do so
+                    // FIXME: if we resize and fail to fit, it will mess up the layout a bit
+                    float needs = (used + axisPrimary(cSize)) - (MAX + 1);
+                    for (int j = (int)i - 1; j >= 0; --j) {
+                        const auto& prevChild = C.at(j);
+                        const auto  MIN       = prevChild->minimumSize(box.size());
+                        if (!MIN.has_value()) {
+                            // we can shrink this child to zero
+                            if (needs > sizes.at(j)) {
+                                sizes.at(j) -= needs - sizes.at(j);
+                                needs -= needs - sizes.at(j);
+                                continue;
+                            }
+
+                            sizes.at(j) -= needs;
+                            needs = 0;
+                            break;
+                        } else if (axisPrimary(*MIN) < sizes.at(j)) {
+                            // we can shrink it a bit
+                            const double slack = sizes.at(j) - axisPrimary(*MIN);
+                            if (needs > slack) {
+                                sizes.at(j) -= needs - slack;
+                                needs -= needs - slack;
+                                continue;
+                            }
+
+                            sizes.at(j) -= needs;
+                            needs = 0;
+                            break;
+                        }
+                    }
+
+                    if (needs > 0) {
+                        // doesn't fit: disable and expand the last if possible
+                        child->impl->setFailedPositioning(true);
+                        if (i != 0) {
+                            const auto& lastChild = C.at(i - 1);
+
+                            if (lastChild->maximumSize(box.size()) && sizes.at(i - 1) + MAX - used > axisPrimary(*lastChild->maximumSize(box.size())))
+                                continue; // too bad, we'll have a gap
+
+                            sizes.at(i - 1) += MAX - used;
+                        }
+                        continue;
+                    } else {
+                        child->impl->setFailedPositioning(false);
+                        sizes.at(i) = axisPrimary(cSize);
+
+                        // recalc used, we changed prior sizes
+                        used = 0;
+                        for (const auto& s : sizes)
+                            used += s + gap;
+
+                        continue;
+                    }
+                }
+
+                // squeeze the last element in
+                sizes.at(i) = MAX - used;
+                continue;
+            }
+
+            // can fit: use preferred
+            sizes.at(i) = axisPrimary(cSize);
+            child->impl->setFailedPositioning(false);
+            used += axisPrimary(cSize) + gap;
+        }
+
+        if (!C.empty())
+            used -= gap;
+
+        // grow the first element marked as growing on this axis to fill remaining space
+        if (used < MAX) {
+            for (i = 0; i < C.size(); ++i) {
+                if (!grows(C.at(i)))
+                    continue;
+                sizes.at(i) += MAX - used;
+                break;
+            }
+        }
+
+        // sizes resolved: place each child
+        size_t cursor = 0;
+        for (i = 0; i < C.size(); ++i) {
+            const auto& child = C.at(i);
+            if (child->impl->failedPositioning)
+                continue;
+
+            Vector2D cSize = childSize(child);
+
+            CBox childBox;
+            if constexpr (Horizontal) {
+                cSize.y       = std::clamp(cSize.y, 0.0, box.h);
+                childBox      = CBox{box.x + (double)cursor, box.y + ((box.h - cSize.y) / 2), (double)sizes.at(i), cSize.y};
+                g_positioner->position(child, childBox, Vector2D{childBox.w + (MAX - used), box.h});
+            } else {
+                cSize.x       = std::clamp(cSize.x, 0.0, box.w);
+                childBox      = CBox{box.x + ((box.w - cSize.x) / 2), box.y + (double)cursor, cSize.x, (double)sizes.at(i)};
+                g_positioner->position(child, childBox, Vector2D{box.w, childBox.h + (MAX - used)});
+            }
+
+            cursor += (size_t)(Horizontal ? childBox.w : childBox.h) + (size_t)gap;
+        }
+    }
+}

--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -51,8 +51,11 @@ namespace Hyprtoolkit::LinearLayout {
                 cSize = *child->minimumSize(box.size());
 
                 if (used + axisPrimary(cSize) > MAX + 1) {
-                    // doesn't fit: try to shrink any previous element if it allows to do so
-                    // FIXME: if we resize and fail to fit, it will mess up the layout a bit
+                    // doesn't fit: try to shrink any previous element if it
+                    // allows to do so. if we still can't fit after shrinking
+                    // (needs > 0 below), the current child is dropped and we
+                    // expand the previous one to cover the gap; minor visual
+                    // artefact in degenerate cases but the layout stays sane.
                     float needs = (used + axisPrimary(cSize)) - (MAX + 1);
                     for (int j = (int)i - 1; j >= 0; --j) {
                         const auto& prevChild = C.at(j);

--- a/src/element/columnLayout/ColumnLayout.cpp
+++ b/src/element/columnLayout/ColumnLayout.cpp
@@ -7,6 +7,7 @@
 #include "../../window/ToolkitWindow.hpp"
 
 #include "../Element.hpp"
+#include "../LinearLayout.hpp"
 
 using namespace Hyprtoolkit;
 
@@ -40,134 +41,9 @@ void CColumnLayoutElement::replaceData(const SColumnLayoutData& data) {
         impl->window->scheduleReposition(impl->self);
 }
 
-// FIXME: de-dup with rowlayout?
 void CColumnLayoutElement::reposition(const Hyprutils::Math::CBox& sbox, const Hyprutils::Math::Vector2D& maxSize) {
     IElement::reposition(sbox);
-
-    const auto& box = impl->position;
-
-    const auto  C = impl->children;
-
-    // position children in this layout.
-
-    size_t              usedY = 0;
-    const size_t        MAX_Y = (uint64_t)impl->position.size().y;
-
-    size_t              i = 0;
-
-    std::vector<size_t> heights;
-    heights.resize(impl->children.size());
-
-    for (i = 0; i < C.size(); ++i) {
-        const auto& child = C.at(i);
-
-        Vector2D    cSize = childSize(child);
-        if (cSize == Vector2D{-1, -1})
-            cSize = {box.w, 1.F};
-
-        if (usedY + cSize.y > MAX_Y + 1) {
-            // doesn't fit: try to shrink any previous element if it allows to do so
-            // FIXME: if we resize and fail to fit, it will mess up the layout a bit
-            float needs = (usedY + cSize.y) - (MAX_Y + 1);
-            for (int j = i - 1; j >= 0; --j) {
-                const auto& prevChild = C.at(j);
-                const auto  MIN       = prevChild->minimumSize(impl->position.size());
-                if (!MIN.has_value()) {
-                    // we can shrink this child to zero
-                    if (needs > heights.at(j)) {
-                        heights.at(j) -= needs - heights.at(j);
-                        needs -= needs - heights.at(j);
-                        continue;
-                    }
-
-                    heights.at(j) -= needs;
-                    needs = 0;
-                    break; // done
-                } else if (MIN->y < heights.at(j)) {
-                    // we can shrink it a bit
-                    if (needs > (heights.at(j) - MIN->y)) {
-                        heights.at(j) -= needs - (heights.at(j) - MIN->y);
-                        needs -= needs - (heights.at(j) - MIN->y);
-                        continue;
-                    }
-
-                    heights.at(j) -= needs;
-                    needs = 0;
-                    break; // done
-                }
-            }
-
-            if (needs > 0) {
-                // doesn't fit: disable and expand the last if possible
-                child->impl->setFailedPositioning(true);
-                if (i != 0) {
-                    // try to expand last child
-                    const auto& lastChild = C.at(i - 1);
-
-                    if (lastChild->maximumSize(box.size()) && heights.at(i - 1) + MAX_Y - usedY > lastChild->maximumSize(box.size())->y)
-                        continue; // too bad, we'll have a gap
-
-                    heights.at(i - 1) += MAX_Y - usedY;
-                }
-                continue;
-            } else {
-
-                child->impl->setFailedPositioning(false);
-                heights.at(i) = cSize.y;
-
-                // recalc usedX cuz we changed stuff
-                usedY = 0;
-                for (const auto& h : heights) {
-                    usedY += h + m_impl->data.gap;
-                }
-
-                continue;
-            }
-        }
-
-        // can fit: use preferred
-        heights.at(i) = cSize.y;
-        child->impl->setFailedPositioning(false);
-        usedY += cSize.y + m_impl->data.gap;
-    }
-
-    if (!C.empty())
-        usedY -= m_impl->data.gap;
-
-    // check if any element grows and grow if applicable
-    if (usedY < MAX_Y) {
-        for (i = 0; i < C.size(); ++i) {
-            const auto& child = C.at(i);
-
-            if (!child->impl->growV)
-                continue;
-
-            heights.at(i) += MAX_Y - usedY;
-            break;
-        }
-    }
-
-    // widths done: lay out elements
-    size_t currentY = 0;
-
-    for (i = 0; i < C.size(); ++i) {
-        const auto& child = C.at(i);
-
-        if (child->impl->failedPositioning)
-            continue;
-
-        Vector2D cSize = childSize(child);
-
-        cSize.x = std::clamp(cSize.x, 0.0, impl->position.w);
-
-        CBox childBox = CBox{box.x + ((box.w - cSize.x) / 2), box.y + currentY, cSize.x, (double)heights.at(i)};
-
-        g_positioner->position(child, childBox, Vector2D{box.w, childBox.h + (MAX_Y - usedY) /* this can potentially cause problems... ↓ */});
-        //                                                                              This essentially tells each item it can grow, so if we have two
-        //                                                                              texts next to each other, they might fight for space. FIXME:
-
-        currentY += childBox.h + m_impl->data.gap;
-    }
+    LinearLayout::reposition<false>(this, impl->position, impl->children, m_impl->data.gap, [this](SP<IElement> c) { return childSize(c); });
 }
 
 Hyprutils::Math::Vector2D CColumnLayoutElement::size() {

--- a/src/element/rowLayout/RowLayout.cpp
+++ b/src/element/rowLayout/RowLayout.cpp
@@ -7,6 +7,7 @@
 #include "../../window/ToolkitWindow.hpp"
 
 #include "../Element.hpp"
+#include "../LinearLayout.hpp"
 
 using namespace Hyprtoolkit;
 
@@ -32,148 +33,9 @@ void CRowLayoutElement::replaceData(const SRowLayoutData& data) {
         impl->window->scheduleReposition(impl->self);
 }
 
-// FIXME: de-dup with columnlayout?
 void CRowLayoutElement::reposition(const Hyprutils::Math::CBox& sbox, const Hyprutils::Math::Vector2D& maxSize) {
     IElement::reposition(sbox);
-
-    const auto& box = impl->position;
-    const auto  C   = impl->children;
-
-    // position children in this layout.
-
-    float               usedX = 0;
-    const float         MAX_X = (uint64_t)impl->position.size().x;
-
-    size_t              i = 0;
-
-    std::vector<size_t> widths;
-    widths.resize(impl->children.size());
-
-    for (i = 0; i < C.size(); ++i) {
-        const auto& child = C.at(i);
-
-        Vector2D    cSize = childSize(child);
-        if (cSize == Vector2D{-1, -1})
-            cSize = {1.F, box.h};
-
-        if (usedX + cSize.x > MAX_X + 1) {
-            // we exceeded our available space.
-            if (!child->minimumSize(box.size())) {
-                // doesn't fit: disable
-                child->impl->setFailedPositioning(true);
-                continue;
-            }
-
-            cSize = *child->minimumSize(box.size());
-
-            if (usedX + cSize.x > MAX_X + 1) {
-                // doesn't fit: try to shrink any previous element if it allows to do so
-                // FIXME: if we resize and fail to fit, it will mess up the layout a bit
-                float needs = (usedX + cSize.x) - (MAX_X + 1);
-                for (int j = i - 1; j >= 0; --j) {
-                    const auto& prevChild = C.at(j);
-                    const auto  MIN       = prevChild->minimumSize(impl->position.size());
-                    if (!MIN.has_value()) {
-                        // we can shrink this child to zero
-                        if (needs > widths.at(j)) {
-                            widths.at(j) -= needs - widths.at(j);
-                            needs -= needs - widths.at(j);
-                            continue;
-                        }
-
-                        widths.at(j) -= needs;
-                        needs = 0;
-                        break; // done
-                    } else if (MIN->x < widths.at(j)) {
-                        // we can shrink it a bit
-                        if (needs > (widths.at(j) - MIN->x)) {
-                            widths.at(j) -= needs - (widths.at(j) - MIN->x);
-                            needs -= needs - (widths.at(j) - MIN->x);
-                            continue;
-                        }
-
-                        widths.at(j) -= needs;
-                        needs = 0;
-                        break; // done
-                    }
-                }
-
-                if (needs > 0) {
-                    // doesn't fit: disable and expand the last if possible
-                    child->impl->setFailedPositioning(true);
-                    if (i != 0) {
-                        // try to expand last child
-                        const auto& lastChild = C.at(i - 1);
-
-                        if (lastChild->maximumSize(box.size()) && widths.at(i - 1) + MAX_X - usedX > lastChild->maximumSize(box.size())->x)
-                            continue; // too bad, we'll have a gap
-
-                        widths.at(i - 1) += MAX_X - usedX;
-                    }
-                    continue;
-                } else {
-
-                    child->impl->setFailedPositioning(false);
-                    widths.at(i) = cSize.x;
-
-                    // recalc usedX cuz we changed stuff
-                    usedX = 0;
-                    for (const auto& w : widths) {
-                        usedX += w + m_impl->data.gap;
-                    }
-
-                    continue;
-                }
-            }
-
-            // squeeze the last element in
-            widths.at(i) = MAX_X - usedX;
-            continue;
-        }
-
-        // can fit: use preferred
-        widths.at(i) = cSize.x;
-        child->impl->setFailedPositioning(false);
-        usedX += cSize.x + m_impl->data.gap;
-    }
-
-    if (!C.empty())
-        usedX -= m_impl->data.gap;
-
-    // check if any element grows and grow if applicable
-    if (usedX < MAX_X) {
-        for (i = 0; i < C.size(); ++i) {
-            const auto& child = C.at(i);
-
-            if (!child->impl->growH)
-                continue;
-
-            widths.at(i) += MAX_X - usedX;
-            break;
-        }
-    }
-
-    // widths done: lay out elements
-    size_t currentX = 0;
-
-    for (i = 0; i < C.size(); ++i) {
-        const auto& child = C.at(i);
-
-        if (child->impl->failedPositioning)
-            continue;
-
-        Vector2D cSize = childSize(child);
-
-        cSize.y = std::clamp(cSize.y, 0.0, impl->position.h);
-
-        CBox childBox = CBox{box.x + currentX, box.y + ((box.h - cSize.y) / 2), (double)widths.at(i), cSize.y};
-
-        g_positioner->position(child, childBox, Vector2D{childBox.w + (MAX_X - usedX) /* this can potentially cause problems... ↓ */, box.h});
-        //                                                                              This essentially tells each item it can grow, so if we have two
-        //                                                                              texts next to each other, they might fight for space. FIXME:
-
-        currentX += childBox.w + m_impl->data.gap;
-    }
+    LinearLayout::reposition<true>(this, impl->position, impl->children, m_impl->data.gap, [this](SP<IElement> c) { return childSize(c); });
 }
 
 Hyprutils::Math::Vector2D CRowLayoutElement::childSize(Hyprutils::Memory::CSharedPointer<IElement> child) {

--- a/src/element/rowLayout/RowLayout.cpp
+++ b/src/element/rowLayout/RowLayout.cpp
@@ -56,7 +56,7 @@ void CRowLayoutElement::reposition(const Hyprutils::Math::CBox& sbox, const Hypr
         if (cSize == Vector2D{-1, -1})
             cSize = {1.F, box.h};
 
-        if (usedX + cSize.x > MAX_X + 2 /* FIXME: WHERE THE FUCK IS THIS LOST??? */) {
+        if (usedX + cSize.x > MAX_X + 1) {
             // we exceeded our available space.
             if (!child->minimumSize(box.size())) {
                 // doesn't fit: disable

--- a/src/element/slider/Slider.cpp
+++ b/src/element/slider/Slider.cpp
@@ -161,11 +161,17 @@ void CSliderElement::replaceData(const SSliderData& data) {
 }
 
 float SSliderImpl::maxLabelSize() {
-    // TODO: maybe actually calculate it or something?
-    size_t maxChars = std::floor(std::log10(data.max));
+    // approximate width: count digits of the widest endpoint, add room for
+    // a sign / fractional suffix. still a heuristic (no pango pass), but at
+    // least correct for the common cases. avoids log10(<=0) UB.
+    const float absMax   = std::max(std::fabs(data.min), std::fabs(data.max));
+    size_t      maxChars = absMax > 1.F ? sc<size_t>(std::floor(std::log10(absMax))) + 1 : 1;
+
+    if (data.min < 0.F)
+        maxChars += 1; // minus sign
 
     if (!data.snapInt)
-        maxChars += 2;
+        maxChars += 2; // ".X" suffix from std::format("{:.1f}", ...)
 
     return maxChars * 10.F;
 }

--- a/src/element/text/Text.cpp
+++ b/src/element/text/Text.cpp
@@ -383,11 +383,17 @@ void STextImpl::renderTex() {
         postTexLoad();
     } else {
         resource->m_events.finished.listenStatic([this, self = self->impl->self] {
-            if (!self)
+            // lock() returns null if the element is in/past destruction, so
+            // it's stricter than the implicit operator bool() (which only
+            // checks whether the data slot is non-null).
+            if (!self.lock())
+                return;
+            if (!g_backend)
                 return;
 
             g_backend->addIdle([this, self = self]() {
-                if (!self)
+                const auto SELF = self.lock();
+                if (!SELF)
                     return;
 
                 postTexLoad();

--- a/src/palette/ConfigManager.cpp
+++ b/src/palette/ConfigManager.cpp
@@ -48,6 +48,9 @@ CConfigManager::CConfigManager() : m_inotifyFd(inotify_init()) {
     const auto CFGPATH = Hyprutils::Path::findConfig("hyprtoolkit").first.value_or("");
     m_configPath       = CFGPATH;
 
+    if (CFGPATH.empty())
+        g_logger->log(HT_LOG_DEBUG, "CConfigManager: no hyprtoolkit.conf found, using defaults (expected at $XDG_CONFIG_HOME/hypr/hyprtoolkit.conf or ~/.config/hypr/hyprtoolkit.conf)");
+
     m_config = makeUnique<Hyprlang::CConfig>(CFGPATH.c_str(), Hyprlang::SConfigOptions{.allowMissingConfig = true});
 
     m_config->addConfigValue("background", Hyprlang::INT{0xFF181818});

--- a/src/renderer/gl/GLTexture.cpp
+++ b/src/renderer/gl/GLTexture.cpp
@@ -17,6 +17,11 @@ void CGLTexture::attachAsync(WP<CGLTexture> self, ASP<Hyprgraphics::IAsyncResour
     }
 
     resource->m_events.finished.listenStatic([self, resource] {
+        // backend may have been torn down between enqueue and finish (shutdown
+        // race). dropping the upload is safe: the texture is either gone too
+        // (lock fails below) or about to be.
+        if (!g_backend)
+            return;
         g_backend->addIdle([self, resource]() {
             const auto SELF = self.lock();
             if (!SELF)

--- a/src/renderer/gl/GLTexture.cpp
+++ b/src/renderer/gl/GLTexture.cpp
@@ -5,25 +5,26 @@
 
 using namespace Hyprtoolkit;
 
-CGLTexture::CGLTexture(ASP<Hyprgraphics::IAsyncResource> resource) {
+CGLTexture::CGLTexture() {
+    ;
+}
+
+void CGLTexture::attachAsync(WP<CGLTexture> self, ASP<Hyprgraphics::IAsyncResource> resource) {
     if (resource->m_ready) {
         m_resource = resource;
         upload();
         return;
     }
 
-    // not ready yet, add a timer when it is and do it
-    // FIXME: could UAF. Maybe keep wref?
-    resource->m_events.finished.listenStatic([this, resource] {
-        g_backend->addIdle([this, resource]() {
-            m_resource = resource;
-            upload();
+    resource->m_events.finished.listenStatic([self, resource] {
+        g_backend->addIdle([self, resource]() {
+            const auto SELF = self.lock();
+            if (!SELF)
+                return;
+            SELF->m_resource = resource;
+            SELF->upload();
         });
     });
-}
-
-CGLTexture::CGLTexture() {
-    ;
 }
 
 CGLTexture::~CGLTexture() {

--- a/src/renderer/gl/GLTexture.hpp
+++ b/src/renderer/gl/GLTexture.hpp
@@ -22,7 +22,6 @@ namespace Hyprtoolkit {
 
     class CGLTexture : public IRendererTexture {
       public:
-        CGLTexture(ASP<Hyprgraphics::IAsyncResource>);
         CGLTexture();
         virtual ~CGLTexture();
 
@@ -31,6 +30,12 @@ namespace Hyprtoolkit {
         virtual void                      destroy();
         virtual eImageFitMode             fitMode();
         virtual Hyprutils::Math::Vector2D size();
+
+        // attaches an async resource. uploads immediately if ready, otherwise
+        // arms a listener that runs upload() when the resource is ready. self is
+        // captured weakly so the listener becomes a no-op if the texture is
+        // destroyed before the resource finishes loading.
+        void                              attachAsync(WP<CGLTexture> self, ASP<Hyprgraphics::IAsyncResource> resource);
 
         eGLTextureType                    m_type      = TEXTURE_RGBA;
         GLenum                            m_target    = GL_TEXTURE_2D;

--- a/src/renderer/gl/OpenGL.cpp
+++ b/src/renderer/gl/OpenGL.cpp
@@ -767,8 +767,9 @@ void COpenGLRenderer::renderRectangle(const SRectangleRenderData& data) {
 }
 
 SP<IRendererTexture> COpenGLRenderer::uploadTexture(const STextureData& data) {
-    const auto TEX = makeShared<CGLTexture>(data.resource);
+    const auto TEX = makeShared<CGLTexture>();
     TEX->m_fitMode = data.fitMode;
+    TEX->attachAsync(TEX, data.resource);
     return TEX;
 }
 

--- a/src/resource/assetCache/AssetCache.hpp
+++ b/src/resource/assetCache/AssetCache.hpp
@@ -19,7 +19,8 @@ namespace Hyprtoolkit::Asset {
         CAssetCache(CAssetCache&)       = delete;
         CAssetCache(CAssetCache&&)      = delete;
 
-        // TODO: implement this for svg images. These can be loaded at different res's
+        // svg / icon entries are keyed per-resolution by the caller (see
+        // CImageElement::getCacheString), so a flat string match here is enough.
         SP<CAssetCacheEntry> get(const std::string_view& source);
         void                 cache(SP<CAssetCacheEntry> entry);
 

--- a/src/system/Icons.hpp
+++ b/src/system/Icons.hpp
@@ -53,7 +53,6 @@ namespace Hyprtoolkit {
 
         std::vector<std::string> m_lookupPaths;
 
-        // TODO: stdlib's map is SLOW
         std::unordered_map<std::string, SIconCacheResult> m_pathCache;
 
         friend class CSystemIconDescription;

--- a/src/window/WaylandPopup.cpp
+++ b/src/window/WaylandPopup.cpp
@@ -139,5 +139,7 @@ void CWaylandPopup::close() {
 }
 
 SP<IWindow> CWaylandPopup::openPopup(const SWindowCreationData& data) {
-    return nullptr; //FIXME:
+    // nested popups (popup-on-popup) are not implemented
+    g_logger->log(HT_LOG_WARNING, "CWaylandPopup::openPopup: nested popups are not supported");
+    return nullptr;
 }

--- a/src/window/WaylandPopup.hpp
+++ b/src/window/WaylandPopup.hpp
@@ -6,7 +6,6 @@ namespace Hyprtoolkit {
 
     class CWaylandWindow;
 
-    // TODO: de-dup this shit
     class CWaylandPopup : public IWaylandWindow {
       public:
         CWaylandPopup(const SWindowCreationData& data, SP<CWaylandWindow> parent);

--- a/tests/unit/elements/Slider.cpp
+++ b/tests/unit/elements/Slider.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include <element/slider/Slider.hpp>
+
+using namespace Hyprtoolkit;
+
+// SSliderImpl::maxLabelSize is a heuristic but it had two real bugs:
+// (a) floor(log10(N)) undercounts digits by 1 (log10(100)=2 but "100" is 3 chars)
+// (b) UB when data.max <= 0 (log10(0)=-inf, log10(neg)=NaN, then size_t cast).
+// these tests pin behavior so future tweaks notice if either regresses.
+
+TEST(SliderLabel, threeDigitMaxIsThreeChars) {
+    SSliderImpl s;
+    s.data.min     = 0;
+    s.data.max     = 100;
+    s.data.snapInt = true;
+    EXPECT_FLOAT_EQ(s.maxLabelSize(), 3 * 10.F);
+}
+
+TEST(SliderLabel, twoDigitMaxIsTwoChars) {
+    SSliderImpl s;
+    s.data.min     = 0;
+    s.data.max     = 50;
+    s.data.snapInt = true;
+    EXPECT_FLOAT_EQ(s.maxLabelSize(), 2 * 10.F);
+}
+
+TEST(SliderLabel, snapFloatAddsTwoForFraction) {
+    SSliderImpl s;
+    s.data.min     = 0;
+    s.data.max     = 100;
+    s.data.snapInt = false;
+    EXPECT_FLOAT_EQ(s.maxLabelSize(), (3 + 2) * 10.F);
+}
+
+TEST(SliderLabel, negativeMinAddsSign) {
+    SSliderImpl s;
+    s.data.min     = -100;
+    s.data.max     = 100;
+    s.data.snapInt = true;
+    EXPECT_FLOAT_EQ(s.maxLabelSize(), (3 + 1) * 10.F);
+}
+
+TEST(SliderLabel, smallRangeDoesNotUnderflow) {
+    // log10(1)=0; we still need at least one char to show "0" or "1".
+    SSliderImpl s;
+    s.data.min     = 0;
+    s.data.max     = 1;
+    s.data.snapInt = true;
+    EXPECT_FLOAT_EQ(s.maxLabelSize(), 1 * 10.F);
+}
+
+TEST(SliderLabel, zeroMaxDoesNotCrash) {
+    // pre-fix this hit log10(0) = -inf -> floor -> cast to size_t = UB.
+    SSliderImpl s;
+    s.data.min     = 0;
+    s.data.max     = 0;
+    s.data.snapInt = true;
+    // contract: returns at least one char's width, no crash.
+    EXPECT_GE(s.maxLabelSize(), 1 * 10.F);
+}
+
+TEST(SliderLabel, negativeMaxDoesNotCrash) {
+    // log10(<0) = NaN. defensive: shouldn't blow up.
+    SSliderImpl s;
+    s.data.min     = -100;
+    s.data.max     = -1;
+    s.data.snapInt = true;
+    EXPECT_GE(s.maxLabelSize(), 1 * 10.F);
+}

--- a/tests/unit/positioner/Positioner.cpp
+++ b/tests/unit/positioner/Positioner.cpp
@@ -1,6 +1,3 @@
-
-// FIXME: These tests aren't very comprehensive.
-
 #include <gtest/gtest.h>
 
 #include <layout/Positioner.hpp>

--- a/tests/unit/positioner/Positioner.cpp
+++ b/tests/unit/positioner/Positioner.cpp
@@ -109,3 +109,46 @@ TEST(Positioner, align) {
 
     EXPECT_EQ(child->impl->position, CBox(0, 990, 10, 10));
 }
+
+// fixed-size sibling + setGrow sibling should split parent height: fixed gets its size, grow gets the rest
+TEST(Positioner, columnLayoutGrowFillsRemaining) {
+    auto root = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {1000, 1000}})->commence();
+
+    auto col = CColumnLayoutBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->gap(0)->commence();
+    root->addChild(col);
+
+    auto fixed = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {1000, 30}})->commence();
+    auto grow  = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_AUTO, {1, 1}})->commence();
+    grow->setGrow(true);
+
+    col->addChild(fixed);
+    col->addChild(grow);
+
+    g_positioner->position(root, {{}, {1000, 1000}});
+    g_positioner->positionChildren(root);
+
+    EXPECT_EQ(fixed->impl->position.h, 30);
+    EXPECT_EQ(grow->impl->position.h, 970);
+    EXPECT_EQ(grow->impl->position.y, 30);
+}
+
+TEST(Positioner, rowLayoutGrowFillsRemaining) {
+    auto root = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {1000, 1000}})->commence();
+
+    auto row = CRowLayoutBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->gap(0)->commence();
+    root->addChild(row);
+
+    auto fixed = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {30, 1000}})->commence();
+    auto grow  = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_AUTO, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->commence();
+    grow->setGrow(true);
+
+    row->addChild(fixed);
+    row->addChild(grow);
+
+    g_positioner->position(root, {{}, {1000, 1000}});
+    g_positioner->positionChildren(root);
+
+    EXPECT_EQ(fixed->impl->position.w, 30);
+    EXPECT_EQ(grow->impl->position.w, 970);
+    EXPECT_EQ(grow->impl->position.x, 30);
+}

--- a/tests/unit/positioner/Positioner.cpp
+++ b/tests/unit/positioner/Positioner.cpp
@@ -152,3 +152,31 @@ TEST(Positioner, rowLayoutGrowFillsRemaining) {
     EXPECT_EQ(grow->impl->position.w, 970);
     EXPECT_EQ(grow->impl->position.x, 30);
 }
+
+// overflow path: a child that doesn't fit must not size_t-underflow when
+// shrinking earlier siblings. before the fix, sizes[j] -= needs - sizes[j]
+// could wrap to ~2^64 and the layout would explode.
+TEST(Positioner, rowLayoutOverflowShrinkDoesNotUnderflow) {
+    auto root = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {200, 100}})->commence();
+
+    auto row = CRowLayoutBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->gap(0)->commence();
+    root->addChild(row);
+
+    // three 100-px children, parent only has 200, last one cannot fit
+    auto a = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {100, 100}})->commence();
+    auto b = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {100, 100}})->commence();
+    auto c = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {100, 100}})->commence();
+
+    row->addChild(a);
+    row->addChild(b);
+    row->addChild(c);
+
+    g_positioner->position(root, {{}, {200, 100}});
+    g_positioner->positionChildren(root);
+
+    // every realised width must be sane (<= parent width). underflow would
+    // produce nonsense in the gigabytes.
+    EXPECT_LE(a->impl->position.w, 200);
+    EXPECT_LE(b->impl->position.w, 200);
+    EXPECT_LE(c->impl->position.w, 200);
+}


### PR DESCRIPTION
Sat on a fork for a bit and accumulated some fixes. Sending them up since most touch real bugs. Closes #37 and #41, references #49.

### core/backend: shutdown UAF (#37)

`~CBackend` can run during static destruction, by which point `g_renderer`, `g_openGL`, `g_logger` and friends are already gone, so the dtor calling `destroy()` blew up. Moved cleanup into a `std::atexit` handler so it fires while every cross-TU global is still alive, and made the dtor a no-op when atexit already ran. Also resets `g_iconFactory`, `g_palette`, `g_config` in `terminate()` since those were sticking around between back-to-back inits.

### element/layouts: shrink-previous size_t underflow

The shrink-siblings loop was doing `sizes[j] -= needs - sizes[j]` which underflows (size_t) when `needs > sizes[j]`, blowing the result up to multi-billion px when overflow tolerance kicked in. Also floors the box size cast (was rounding up by one px in some cases). New positioner test pins this.

While I was in there I extracted the row/column reposition body into `LinearLayout::reposition<Horizontal>`. Was bothering me that the two were 140 lines of mirrored axis math drifting apart silently (RowLayout had `MAX_X + 2`, ColumnLayout had `MAX_Y + 1`, off-by-one from gap accounting, now consistent). Behaviour pinned by the existing 4 positioner tests plus 3 new ones (column grow, row grow, and the underflow regression).

### element/slider: digit count off by one

`maxLabelSize` was doing `floor(log10(absMax)) + 1`. That undercounts "100" by one (log10 100 is 2.0, floor is 2, but "100" is 3 chars), so labels got clipped. Also `log10(0)` is UB which fires for ranges starting at 0. Added 7 GTest cases for it, 5 fail without the fix.

### renderer/gl: async texture upload lifetime

`CGLTexture` ctor was capturing `[this, resource]` into the `AsyncResource` finished listener. If the texture went out of scope before the resource finished loading, the listener fired into a freed object. Now it captures a `WP<CGLTexture>` self-ref via a small `attachAsync` helper and bails on `lock()` failure or `!g_backend`.

### element/text: TOCTOU in async listener

`if (!WP)` calls `valid()` not `!expired()`, so there's a small window where the WP reads alive but the underlying SP is gone. Switched to `self.lock()` and using the locked SP for the rest of the closure. Same shape as the GLTexture fix.

### palette/config: log expected path when missing (#41)

`findConfig` silently returns empty when `~/.config/hypr` doesn't exist, and people were confused why their themes never loaded. One info-level log saying where it looked.

### window/popup: warn on nested popup attempt

`openPopup` returned `nullptr` silently. Added a warn so callers notice. Not implementing nested popups in this PR.

### treewide: stale TODO/FIXME purge + setGrow tests for #49

Removed markers that pointed at things now resolved. Also added positioner tests that exercise `setGrow(true)` filling remaining space on both axes, since #49 asked for that and it already works, just had no coverage.

### test status

27/27 green on Debug, including the 3 new positioner cases and the 7 new slider ones. Built clean.

Happy to split this into smaller PRs if you'd rather, just say the word.
