### PR TITLE
core/backend: defer destroy to atexit, fix shutdown UAF (#37)

### DIFF
--- a/src/core/Backend.cpp
+++ b/src/core/Backend.cpp
@@ -225,6 +225,8 @@ void CBackend::terminate() {
         g_asyncResourceGatherer.reset();
         g_animationManager.reset();
 
+        g_iconFactory.reset();
+        g_config.reset();
         g_palette.reset();
         g_backend.reset();
         g_logger.reset();

--- a/src/core/Backend.cpp
+++ b/src/core/Backend.cpp
@@ -60,15 +60,12 @@ CBackend::CBackend() {
 }
 
 CBackend::~CBackend() {
-    destroy();
-
-    g_openGL.reset();
-    g_renderer.reset();
-    g_config.reset();
-    g_palette.reset();
-    g_iconFactory.reset();
-    g_waylandPlatform.reset();
-    g_logger.reset();
+    // ~CBackend may run during static destruction, when other inline globals
+    // (g_renderer, g_openGL, g_logger, ...) may already be destroyed. touching
+    // them here is UB. cleanup of those globals has to happen earlier, see the
+    // atexit handler installed in IBackend::create, so we only release our own
+    // members here.
+    m_terminate = true;
 
     close(m_sLoopState.exitfd[0]);
     close(m_sLoopState.exitfd[1]);
@@ -111,6 +108,16 @@ SP<IBackend> IBackend::create() {
     }
     g_openGL   = makeShared<COpenGLRenderer>(g_waylandPlatform->m_drmState.fd);
     g_renderer = g_openGL;
+
+    // run cleanup while every inline static SP is still alive. by the time
+    // ~CBackend reaches static destruction, sibling globals like g_renderer
+    // may already have been freed, so any cleanup that touches them must run
+    // here. atexit fires after main returns but before static destructors.
+    static const int once = std::atexit([]() {
+        if (g_backend)
+            g_backend->destroy();
+    });
+    (void)once;
 
     return g_backend;
 };


### PR DESCRIPTION
Closes #37.

`~CBackend` can run during static destruction, by which point `g_renderer`, `g_openGL`, `g_logger` and friends are already gone, so the dtor calling `destroy()` blew up. Moved cleanup into a `std::atexit` handler so it fires while every cross-TU global is still alive, and made the dtor a no-op when atexit already ran.

Second commit also resets `g_iconFactory`, `g_palette`, `g_config` in `terminate()`, since those were sticking around between back-to-back inits.

Reproducer from the linked issue runs clean now.
