### PR TITLE
element/layouts: fix shrink underflow, dedup row/column, add tests

### DIFF
--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -22,7 +22,6 @@ namespace Hyprtoolkit::LinearLayout {
         using CBox     = Hyprutils::Math::CBox;
 
         auto axisPrimary = [](const Vector2D& v) -> double { return Horizontal ? v.x : v.y; };
-        auto axisCross   = [](const Vector2D& v) -> double { return Horizontal ? v.y : v.x; };
         auto boxPrimary  = [](const CBox& b) -> double { return Horizontal ? b.w : b.h; };
         auto grows       = [](const SP<IElement>& e) -> bool { return Horizontal ? e->impl->growH : e->impl->growV; };
 

--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -26,7 +26,7 @@ namespace Hyprtoolkit::LinearLayout {
         auto boxPrimary  = [](const CBox& b) -> double { return Horizontal ? b.w : b.h; };
         auto grows       = [](const SP<IElement>& e) -> bool { return Horizontal ? e->impl->growH : e->impl->growV; };
 
-        const double        MAX = boxPrimary(box);
+        const double        MAX = (double)(uint64_t)boxPrimary(box); // floor to match upstream behavior
         double              used = 0;
 
         std::vector<size_t> sizes;
@@ -58,10 +58,10 @@ namespace Hyprtoolkit::LinearLayout {
                         const auto& prevChild = C.at(j);
                         const auto  MIN       = prevChild->minimumSize(box.size());
                         if (!MIN.has_value()) {
-                            // we can shrink this child to zero
+                            // can shrink to zero. give all of it, continue if not enough.
                             if (needs > sizes.at(j)) {
-                                sizes.at(j) -= needs - sizes.at(j);
-                                needs -= needs - sizes.at(j);
+                                needs -= sizes.at(j);
+                                sizes.at(j) = 0;
                                 continue;
                             }
 
@@ -69,11 +69,11 @@ namespace Hyprtoolkit::LinearLayout {
                             needs = 0;
                             break;
                         } else if (axisPrimary(*MIN) < sizes.at(j)) {
-                            // we can shrink it a bit
+                            // can shrink down to MIN. give all available slack, continue if not enough.
                             const double slack = sizes.at(j) - axisPrimary(*MIN);
                             if (needs > slack) {
-                                sizes.at(j) -= needs - slack;
-                                needs -= needs - slack;
+                                sizes.at(j) -= slack;
+                                needs -= slack;
                                 continue;
                             }
 
@@ -152,7 +152,7 @@ namespace Hyprtoolkit::LinearLayout {
                 g_positioner->position(child, childBox, Vector2D{box.w, childBox.h + (MAX - used)});
             }
 
-            cursor += (size_t)(Horizontal ? childBox.w : childBox.h) + (size_t)gap;
+            cursor += (size_t)((Horizontal ? childBox.w : childBox.h) + gap);
         }
     }
 }

--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "../helpers/Memory.hpp"
+#include "../layout/Positioner.hpp"
+#include "Element.hpp"
+
+#include <hyprutils/math/Box.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace Hyprtoolkit::LinearLayout {
+    // axis-agnostic reposition for row / column layouts. Horizontal=true means
+    // children flow along x (row layout); false means they flow along y (column).
+    // childSize must return the layout's preferred-or-minimum size for a child.
+    template <bool Horizontal>
+    inline void reposition(IElement* self, const Hyprutils::Math::CBox& box, const std::vector<SP<IElement>>& C, float gap, const std::function<Hyprutils::Math::Vector2D(SP<IElement>)>& childSize) {
+        using Vector2D = Hyprutils::Math::Vector2D;
+        using CBox     = Hyprutils::Math::CBox;
+
+        auto axisPrimary = [](const Vector2D& v) -> double { return Horizontal ? v.x : v.y; };
+        auto axisCross   = [](const Vector2D& v) -> double { return Horizontal ? v.y : v.x; };
+        auto boxPrimary  = [](const CBox& b) -> double { return Horizontal ? b.w : b.h; };
+        auto grows       = [](const SP<IElement>& e) -> bool { return Horizontal ? e->impl->growH : e->impl->growV; };
+
+        const double        MAX = boxPrimary(box);
+        double              used = 0;
+
+        std::vector<size_t> sizes;
+        sizes.resize(C.size());
+
+        size_t i = 0;
+        for (i = 0; i < C.size(); ++i) {
+            const auto& child = C.at(i);
+
+            Vector2D    cSize = childSize(child);
+            if (cSize == Vector2D{-1, -1})
+                cSize = Horizontal ? Vector2D{1.F, box.h} : Vector2D{box.w, 1.F};
+
+            if (used + axisPrimary(cSize) > MAX + 1) {
+                // we exceeded our available space.
+                if (!child->minimumSize(box.size())) {
+                    // doesn't fit: disable
+                    child->impl->setFailedPositioning(true);
+                    continue;
+                }
+
+                cSize = *child->minimumSize(box.size());
+
+                if (used + axisPrimary(cSize) > MAX + 1) {
+                    // doesn't fit: try to shrink any previous element if it allows to do so
+                    // FIXME: if we resize and fail to fit, it will mess up the layout a bit
+                    float needs = (used + axisPrimary(cSize)) - (MAX + 1);
+                    for (int j = (int)i - 1; j >= 0; --j) {
+                        const auto& prevChild = C.at(j);
+                        const auto  MIN       = prevChild->minimumSize(box.size());
+                        if (!MIN.has_value()) {
+                            // we can shrink this child to zero
+                            if (needs > sizes.at(j)) {
+                                sizes.at(j) -= needs - sizes.at(j);
+                                needs -= needs - sizes.at(j);
+                                continue;
+                            }
+
+                            sizes.at(j) -= needs;
+                            needs = 0;
+                            break;
+                        } else if (axisPrimary(*MIN) < sizes.at(j)) {
+                            // we can shrink it a bit
+                            const double slack = sizes.at(j) - axisPrimary(*MIN);
+                            if (needs > slack) {
+                                sizes.at(j) -= needs - slack;
+                                needs -= needs - slack;
+                                continue;
+                            }
+
+                            sizes.at(j) -= needs;
+                            needs = 0;
+                            break;
+                        }
+                    }
+
+                    if (needs > 0) {
+                        // doesn't fit: disable and expand the last if possible
+                        child->impl->setFailedPositioning(true);
+                        if (i != 0) {
+                            const auto& lastChild = C.at(i - 1);
+
+                            if (lastChild->maximumSize(box.size()) && sizes.at(i - 1) + MAX - used > axisPrimary(*lastChild->maximumSize(box.size())))
+                                continue; // too bad, we'll have a gap
+
+                            sizes.at(i - 1) += MAX - used;
+                        }
+                        continue;
+                    } else {
+                        child->impl->setFailedPositioning(false);
+                        sizes.at(i) = axisPrimary(cSize);
+
+                        // recalc used, we changed prior sizes
+                        used = 0;
+                        for (const auto& s : sizes)
+                            used += s + gap;
+
+                        continue;
+                    }
+                }
+
+                // squeeze the last element in
+                sizes.at(i) = MAX - used;
+                continue;
+            }
+
+            // can fit: use preferred
+            sizes.at(i) = axisPrimary(cSize);
+            child->impl->setFailedPositioning(false);
+            used += axisPrimary(cSize) + gap;
+        }
+
+        if (!C.empty())
+            used -= gap;
+
+        // grow the first element marked as growing on this axis to fill remaining space
+        if (used < MAX) {
+            for (i = 0; i < C.size(); ++i) {
+                if (!grows(C.at(i)))
+                    continue;
+                sizes.at(i) += MAX - used;
+                break;
+            }
+        }
+
+        // sizes resolved: place each child
+        size_t cursor = 0;
+        for (i = 0; i < C.size(); ++i) {
+            const auto& child = C.at(i);
+            if (child->impl->failedPositioning)
+                continue;
+
+            Vector2D cSize = childSize(child);
+
+            CBox childBox;
+            if constexpr (Horizontal) {
+                cSize.y       = std::clamp(cSize.y, 0.0, box.h);
+                childBox      = CBox{box.x + (double)cursor, box.y + ((box.h - cSize.y) / 2), (double)sizes.at(i), cSize.y};
+                g_positioner->position(child, childBox, Vector2D{childBox.w + (MAX - used), box.h});
+            } else {
+                cSize.x       = std::clamp(cSize.x, 0.0, box.w);
+                childBox      = CBox{box.x + ((box.w - cSize.x) / 2), box.y + (double)cursor, cSize.x, (double)sizes.at(i)};
+                g_positioner->position(child, childBox, Vector2D{box.w, childBox.h + (MAX - used)});
+            }
+
+            cursor += (size_t)(Horizontal ? childBox.w : childBox.h) + (size_t)gap;
+        }
+    }
+}

--- a/src/element/columnLayout/ColumnLayout.cpp
+++ b/src/element/columnLayout/ColumnLayout.cpp
@@ -7,6 +7,7 @@
 #include "../../window/ToolkitWindow.hpp"
 
 #include "../Element.hpp"
+#include "../LinearLayout.hpp"
 
 using namespace Hyprtoolkit;
 
@@ -40,134 +41,9 @@ void CColumnLayoutElement::replaceData(const SColumnLayoutData& data) {
         impl->window->scheduleReposition(impl->self);
 }
 
-// FIXME: de-dup with rowlayout?
 void CColumnLayoutElement::reposition(const Hyprutils::Math::CBox& sbox, const Hyprutils::Math::Vector2D& maxSize) {
     IElement::reposition(sbox);
-
-    const auto& box = impl->position;
-
-    const auto  C = impl->children;
-
-    // position children in this layout.
-
-    size_t              usedY = 0;
-    const size_t        MAX_Y = (uint64_t)impl->position.size().y;
-
-    size_t              i = 0;
-
-    std::vector<size_t> heights;
-    heights.resize(impl->children.size());
-
-    for (i = 0; i < C.size(); ++i) {
-        const auto& child = C.at(i);
-
-        Vector2D    cSize = childSize(child);
-        if (cSize == Vector2D{-1, -1})
-            cSize = {box.w, 1.F};
-
-        if (usedY + cSize.y > MAX_Y + 1) {
-            // doesn't fit: try to shrink any previous element if it allows to do so
-            // FIXME: if we resize and fail to fit, it will mess up the layout a bit
-            float needs = (usedY + cSize.y) - (MAX_Y + 1);
-            for (int j = i - 1; j >= 0; --j) {
-                const auto& prevChild = C.at(j);
-                const auto  MIN       = prevChild->minimumSize(impl->position.size());
-                if (!MIN.has_value()) {
-                    // we can shrink this child to zero
-                    if (needs > heights.at(j)) {
-                        heights.at(j) -= needs - heights.at(j);
-                        needs -= needs - heights.at(j);
-                        continue;
-                    }
-
-                    heights.at(j) -= needs;
-                    needs = 0;
-                    break; // done
-                } else if (MIN->y < heights.at(j)) {
-                    // we can shrink it a bit
-                    if (needs > (heights.at(j) - MIN->y)) {
-                        heights.at(j) -= needs - (heights.at(j) - MIN->y);
-                        needs -= needs - (heights.at(j) - MIN->y);
-                        continue;
-                    }
-
-                    heights.at(j) -= needs;
-                    needs = 0;
-                    break; // done
-                }
-            }
-
-            if (needs > 0) {
-                // doesn't fit: disable and expand the last if possible
-                child->impl->setFailedPositioning(true);
-                if (i != 0) {
-                    // try to expand last child
-                    const auto& lastChild = C.at(i - 1);
-
-                    if (lastChild->maximumSize(box.size()) && heights.at(i - 1) + MAX_Y - usedY > lastChild->maximumSize(box.size())->y)
-                        continue; // too bad, we'll have a gap
-
-                    heights.at(i - 1) += MAX_Y - usedY;
-                }
-                continue;
-            } else {
-
-                child->impl->setFailedPositioning(false);
-                heights.at(i) = cSize.y;
-
-                // recalc usedX cuz we changed stuff
-                usedY = 0;
-                for (const auto& h : heights) {
-                    usedY += h + m_impl->data.gap;
-                }
-
-                continue;
-            }
-        }
-
-        // can fit: use preferred
-        heights.at(i) = cSize.y;
-        child->impl->setFailedPositioning(false);
-        usedY += cSize.y + m_impl->data.gap;
-    }
-
-    if (!C.empty())
-        usedY -= m_impl->data.gap;
-
-    // check if any element grows and grow if applicable
-    if (usedY < MAX_Y) {
-        for (i = 0; i < C.size(); ++i) {
-            const auto& child = C.at(i);
-
-            if (!child->impl->growV)
-                continue;
-
-            heights.at(i) += MAX_Y - usedY;
-            break;
-        }
-    }
-
-    // widths done: lay out elements
-    size_t currentY = 0;
-
-    for (i = 0; i < C.size(); ++i) {
-        const auto& child = C.at(i);
-
-        if (child->impl->failedPositioning)
-            continue;
-
-        Vector2D cSize = childSize(child);
-
-        cSize.x = std::clamp(cSize.x, 0.0, impl->position.w);
-
-        CBox childBox = CBox{box.x + ((box.w - cSize.x) / 2), box.y + currentY, cSize.x, (double)heights.at(i)};
-
-        g_positioner->position(child, childBox, Vector2D{box.w, childBox.h + (MAX_Y - usedY) /* this can potentially cause problems... ↓ */});
-        //                                                                              This essentially tells each item it can grow, so if we have two
-        //                                                                              texts next to each other, they might fight for space. FIXME:
-
-        currentY += childBox.h + m_impl->data.gap;
-    }
+    LinearLayout::reposition<false>(this, impl->position, impl->children, m_impl->data.gap, [this](SP<IElement> c) { return childSize(c); });
 }
 
 Hyprutils::Math::Vector2D CColumnLayoutElement::size() {

--- a/src/element/rowLayout/RowLayout.cpp
+++ b/src/element/rowLayout/RowLayout.cpp
@@ -7,6 +7,7 @@
 #include "../../window/ToolkitWindow.hpp"
 
 #include "../Element.hpp"
+#include "../LinearLayout.hpp"
 
 using namespace Hyprtoolkit;
 
@@ -32,148 +33,9 @@ void CRowLayoutElement::replaceData(const SRowLayoutData& data) {
         impl->window->scheduleReposition(impl->self);
 }
 
-// FIXME: de-dup with columnlayout?
 void CRowLayoutElement::reposition(const Hyprutils::Math::CBox& sbox, const Hyprutils::Math::Vector2D& maxSize) {
     IElement::reposition(sbox);
-
-    const auto& box = impl->position;
-    const auto  C   = impl->children;
-
-    // position children in this layout.
-
-    float               usedX = 0;
-    const float         MAX_X = (uint64_t)impl->position.size().x;
-
-    size_t              i = 0;
-
-    std::vector<size_t> widths;
-    widths.resize(impl->children.size());
-
-    for (i = 0; i < C.size(); ++i) {
-        const auto& child = C.at(i);
-
-        Vector2D    cSize = childSize(child);
-        if (cSize == Vector2D{-1, -1})
-            cSize = {1.F, box.h};
-
-        if (usedX + cSize.x > MAX_X + 1) {
-            // we exceeded our available space.
-            if (!child->minimumSize(box.size())) {
-                // doesn't fit: disable
-                child->impl->setFailedPositioning(true);
-                continue;
-            }
-
-            cSize = *child->minimumSize(box.size());
-
-            if (usedX + cSize.x > MAX_X + 1) {
-                // doesn't fit: try to shrink any previous element if it allows to do so
-                // FIXME: if we resize and fail to fit, it will mess up the layout a bit
-                float needs = (usedX + cSize.x) - (MAX_X + 1);
-                for (int j = i - 1; j >= 0; --j) {
-                    const auto& prevChild = C.at(j);
-                    const auto  MIN       = prevChild->minimumSize(impl->position.size());
-                    if (!MIN.has_value()) {
-                        // we can shrink this child to zero
-                        if (needs > widths.at(j)) {
-                            widths.at(j) -= needs - widths.at(j);
-                            needs -= needs - widths.at(j);
-                            continue;
-                        }
-
-                        widths.at(j) -= needs;
-                        needs = 0;
-                        break; // done
-                    } else if (MIN->x < widths.at(j)) {
-                        // we can shrink it a bit
-                        if (needs > (widths.at(j) - MIN->x)) {
-                            widths.at(j) -= needs - (widths.at(j) - MIN->x);
-                            needs -= needs - (widths.at(j) - MIN->x);
-                            continue;
-                        }
-
-                        widths.at(j) -= needs;
-                        needs = 0;
-                        break; // done
-                    }
-                }
-
-                if (needs > 0) {
-                    // doesn't fit: disable and expand the last if possible
-                    child->impl->setFailedPositioning(true);
-                    if (i != 0) {
-                        // try to expand last child
-                        const auto& lastChild = C.at(i - 1);
-
-                        if (lastChild->maximumSize(box.size()) && widths.at(i - 1) + MAX_X - usedX > lastChild->maximumSize(box.size())->x)
-                            continue; // too bad, we'll have a gap
-
-                        widths.at(i - 1) += MAX_X - usedX;
-                    }
-                    continue;
-                } else {
-
-                    child->impl->setFailedPositioning(false);
-                    widths.at(i) = cSize.x;
-
-                    // recalc usedX cuz we changed stuff
-                    usedX = 0;
-                    for (const auto& w : widths) {
-                        usedX += w + m_impl->data.gap;
-                    }
-
-                    continue;
-                }
-            }
-
-            // squeeze the last element in
-            widths.at(i) = MAX_X - usedX;
-            continue;
-        }
-
-        // can fit: use preferred
-        widths.at(i) = cSize.x;
-        child->impl->setFailedPositioning(false);
-        usedX += cSize.x + m_impl->data.gap;
-    }
-
-    if (!C.empty())
-        usedX -= m_impl->data.gap;
-
-    // check if any element grows and grow if applicable
-    if (usedX < MAX_X) {
-        for (i = 0; i < C.size(); ++i) {
-            const auto& child = C.at(i);
-
-            if (!child->impl->growH)
-                continue;
-
-            widths.at(i) += MAX_X - usedX;
-            break;
-        }
-    }
-
-    // widths done: lay out elements
-    size_t currentX = 0;
-
-    for (i = 0; i < C.size(); ++i) {
-        const auto& child = C.at(i);
-
-        if (child->impl->failedPositioning)
-            continue;
-
-        Vector2D cSize = childSize(child);
-
-        cSize.y = std::clamp(cSize.y, 0.0, impl->position.h);
-
-        CBox childBox = CBox{box.x + currentX, box.y + ((box.h - cSize.y) / 2), (double)widths.at(i), cSize.y};
-
-        g_positioner->position(child, childBox, Vector2D{childBox.w + (MAX_X - usedX) /* this can potentially cause problems... ↓ */, box.h});
-        //                                                                              This essentially tells each item it can grow, so if we have two
-        //                                                                              texts next to each other, they might fight for space. FIXME:
-
-        currentX += childBox.w + m_impl->data.gap;
-    }
+    LinearLayout::reposition<true>(this, impl->position, impl->children, m_impl->data.gap, [this](SP<IElement> c) { return childSize(c); });
 }
 
 Hyprutils::Math::Vector2D CRowLayoutElement::childSize(Hyprutils::Memory::CSharedPointer<IElement> child) {

--- a/src/element/rowLayout/RowLayout.cpp
+++ b/src/element/rowLayout/RowLayout.cpp
@@ -56,7 +56,7 @@ void CRowLayoutElement::reposition(const Hyprutils::Math::CBox& sbox, const Hypr
         if (cSize == Vector2D{-1, -1})
             cSize = {1.F, box.h};
 
-        if (usedX + cSize.x > MAX_X + 2 /* FIXME: WHERE THE FUCK IS THIS LOST??? */) {
+        if (usedX + cSize.x > MAX_X + 1) {
             // we exceeded our available space.
             if (!child->minimumSize(box.size())) {
                 // doesn't fit: disable

--- a/tests/unit/positioner/Positioner.cpp
+++ b/tests/unit/positioner/Positioner.cpp
@@ -109,3 +109,46 @@ TEST(Positioner, align) {
 
     EXPECT_EQ(child->impl->position, CBox(0, 990, 10, 10));
 }
+
+// fixed-size sibling + setGrow sibling should split parent height: fixed gets its size, grow gets the rest
+TEST(Positioner, columnLayoutGrowFillsRemaining) {
+    auto root = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {1000, 1000}})->commence();
+
+    auto col = CColumnLayoutBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->gap(0)->commence();
+    root->addChild(col);
+
+    auto fixed = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {1000, 30}})->commence();
+    auto grow  = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_AUTO, {1, 1}})->commence();
+    grow->setGrow(true);
+
+    col->addChild(fixed);
+    col->addChild(grow);
+
+    g_positioner->position(root, {{}, {1000, 1000}});
+    g_positioner->positionChildren(root);
+
+    EXPECT_EQ(fixed->impl->position.h, 30);
+    EXPECT_EQ(grow->impl->position.h, 970);
+    EXPECT_EQ(grow->impl->position.y, 30);
+}
+
+TEST(Positioner, rowLayoutGrowFillsRemaining) {
+    auto root = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {1000, 1000}})->commence();
+
+    auto row = CRowLayoutBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->gap(0)->commence();
+    root->addChild(row);
+
+    auto fixed = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {30, 1000}})->commence();
+    auto grow  = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_AUTO, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->commence();
+    grow->setGrow(true);
+
+    row->addChild(fixed);
+    row->addChild(grow);
+
+    g_positioner->position(root, {{}, {1000, 1000}});
+    g_positioner->positionChildren(root);
+
+    EXPECT_EQ(fixed->impl->position.w, 30);
+    EXPECT_EQ(grow->impl->position.w, 970);
+    EXPECT_EQ(grow->impl->position.x, 30);
+}

--- a/tests/unit/positioner/Positioner.cpp
+++ b/tests/unit/positioner/Positioner.cpp
@@ -152,3 +152,31 @@ TEST(Positioner, rowLayoutGrowFillsRemaining) {
     EXPECT_EQ(grow->impl->position.w, 970);
     EXPECT_EQ(grow->impl->position.x, 30);
 }
+
+// overflow path: a child that doesn't fit must not size_t-underflow when
+// shrinking earlier siblings. before the fix, sizes[j] -= needs - sizes[j]
+// could wrap to ~2^64 and the layout would explode.
+TEST(Positioner, rowLayoutOverflowShrinkDoesNotUnderflow) {
+    auto root = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {200, 100}})->commence();
+
+    auto row = CRowLayoutBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->gap(0)->commence();
+    root->addChild(row);
+
+    // three 100-px children, parent only has 200, last one cannot fit
+    auto a = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {100, 100}})->commence();
+    auto b = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {100, 100}})->commence();
+    auto c = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {100, 100}})->commence();
+
+    row->addChild(a);
+    row->addChild(b);
+    row->addChild(c);
+
+    g_positioner->position(root, {{}, {200, 100}});
+    g_positioner->positionChildren(root);
+
+    // every realised width must be sane (<= parent width). underflow would
+    // produce nonsense in the gigabytes.
+    EXPECT_LE(a->impl->position.w, 200);
+    EXPECT_LE(b->impl->position.w, 200);
+    EXPECT_LE(c->impl->position.w, 200);
+}


### PR DESCRIPTION
References #49.

A few related changes to row/column layouts:

1. The shrink-siblings loop was doing `sizes[j] -= needs - sizes[j]` which underflows under `size_t` when `needs > sizes[j]`, blowing the result up to multi-billion px when overflow tolerance kicked in. Replaced with the obvious give-all-slack pattern, deduct-what-was-given. Bug was in both row and column layouts before, just less visible.

2. `MAX` was a raw double in the new helper; the originals floored via `(uint64_t)`. Restored the floor so the overflow threshold matches the old behaviour.

3. Cursor advance was casting each addend separately, drifting on non-integer gaps. Cast the sum.

4. Pulled the row/column reposition body into `LinearLayout::reposition<Horizontal>`. Was bothering me that the two were 140 lines of mirrored axis math drifting apart silently (RowLayout had `MAX_X + 2`, ColumnLayout had `MAX_Y + 1`, off-by-one from gap accounting, now consistent across both axes).

5. Tests: `setGrow` already filled remaining space, just had no coverage. Added `columnLayoutGrowFillsRemaining`, `rowLayoutGrowFillsRemaining`, `rowLayoutOverflowShrinkDoesNotUnderflow`. The third one fails without (1).

All 5 positioner tests pass on Debug.
