### PR TITLE
renderer/gl: capture weak self in async texture upload

### DIFF
--- a/src/renderer/gl/GLTexture.cpp
+++ b/src/renderer/gl/GLTexture.cpp
@@ -5,25 +5,26 @@
 
 using namespace Hyprtoolkit;
 
-CGLTexture::CGLTexture(ASP<Hyprgraphics::IAsyncResource> resource) {
+CGLTexture::CGLTexture() {
+    ;
+}
+
+void CGLTexture::attachAsync(WP<CGLTexture> self, ASP<Hyprgraphics::IAsyncResource> resource) {
     if (resource->m_ready) {
         m_resource = resource;
         upload();
         return;
     }
 
-    // not ready yet, add a timer when it is and do it
-    // FIXME: could UAF. Maybe keep wref?
-    resource->m_events.finished.listenStatic([this, resource] {
-        g_backend->addIdle([this, resource]() {
-            m_resource = resource;
-            upload();
+    resource->m_events.finished.listenStatic([self, resource] {
+        g_backend->addIdle([self, resource]() {
+            const auto SELF = self.lock();
+            if (!SELF)
+                return;
+            SELF->m_resource = resource;
+            SELF->upload();
         });
     });
-}
-
-CGLTexture::CGLTexture() {
-    ;
 }
 
 CGLTexture::~CGLTexture() {

--- a/src/renderer/gl/GLTexture.cpp
+++ b/src/renderer/gl/GLTexture.cpp
@@ -5,10 +5,6 @@
 
 using namespace Hyprtoolkit;
 
-CGLTexture::CGLTexture() {
-    ;
-}
-
 void CGLTexture::attachAsync(WP<CGLTexture> self, ASP<Hyprgraphics::IAsyncResource> resource) {
     if (resource->m_ready) {
         m_resource = resource;
@@ -17,6 +13,11 @@ void CGLTexture::attachAsync(WP<CGLTexture> self, ASP<Hyprgraphics::IAsyncResour
     }
 
     resource->m_events.finished.listenStatic([self, resource] {
+        // backend may have been torn down between enqueue and finish (shutdown
+        // race). dropping the upload is safe: the texture is either gone too
+        // (lock fails below) or about to be.
+        if (!g_backend)
+            return;
         g_backend->addIdle([self, resource]() {
             const auto SELF = self.lock();
             if (!SELF)

--- a/src/renderer/gl/GLTexture.hpp
+++ b/src/renderer/gl/GLTexture.hpp
@@ -22,7 +22,6 @@ namespace Hyprtoolkit {
 
     class CGLTexture : public IRendererTexture {
       public:
-        CGLTexture(ASP<Hyprgraphics::IAsyncResource>);
         CGLTexture();
         virtual ~CGLTexture();
 
@@ -31,6 +30,12 @@ namespace Hyprtoolkit {
         virtual void                      destroy();
         virtual eImageFitMode             fitMode();
         virtual Hyprutils::Math::Vector2D size();
+
+        // attaches an async resource. uploads immediately if ready, otherwise
+        // arms a listener that runs upload() when the resource is ready. self is
+        // captured weakly so the listener becomes a no-op if the texture is
+        // destroyed before the resource finishes loading.
+        void                              attachAsync(WP<CGLTexture> self, ASP<Hyprgraphics::IAsyncResource> resource);
 
         eGLTextureType                    m_type      = TEXTURE_RGBA;
         GLenum                            m_target    = GL_TEXTURE_2D;

--- a/src/renderer/gl/GLTexture.hpp
+++ b/src/renderer/gl/GLTexture.hpp
@@ -22,7 +22,7 @@ namespace Hyprtoolkit {
 
     class CGLTexture : public IRendererTexture {
       public:
-        CGLTexture();
+        CGLTexture() = default;
         virtual ~CGLTexture();
 
         virtual size_t                    id();

--- a/src/renderer/gl/OpenGL.cpp
+++ b/src/renderer/gl/OpenGL.cpp
@@ -767,8 +767,9 @@ void COpenGLRenderer::renderRectangle(const SRectangleRenderData& data) {
 }
 
 SP<IRendererTexture> COpenGLRenderer::uploadTexture(const STextureData& data) {
-    const auto TEX = makeShared<CGLTexture>(data.resource);
+    const auto TEX = makeShared<CGLTexture>();
     TEX->m_fitMode = data.fitMode;
+    TEX->attachAsync(TEX, data.resource);
     return TEX;
 }
 


### PR DESCRIPTION
`CGLTexture` ctor was capturing `[this, resource]` into the `AsyncResource` finished listener. If the texture went out of scope before the resource finished loading, the listener fired into a freed object on the idle thread.

First commit: extracted the listener wiring into `attachAsync(WP<CGLTexture> self, ...)` and captures the weak self by value. The factory grabs `WP_FROM_THIS()` after construction and hands it in. The idle callback locks the WP and bails if the texture is gone.

Second commit: also bails if `g_backend` is gone by the time the listener fires (can happen during shutdown).
