### PR TITLE
element/text: lock weak ref in async listener

### DIFF
--- a/src/element/text/Text.cpp
+++ b/src/element/text/Text.cpp
@@ -383,11 +383,13 @@ void STextImpl::renderTex() {
         postTexLoad();
     } else {
         resource->m_events.finished.listenStatic([this, self = self->impl->self] {
-            if (!self)
+            if (self.expired())
+                return;
+            if (!g_backend)
                 return;
 
             g_backend->addIdle([this, self = self]() {
-                if (!self)
+                if (self.expired())
                     return;
 
                 postTexLoad();


### PR DESCRIPTION
`if (!WP)` calls `WP::operator bool()` which is `valid()` not `!expired()`, so there's a small TOCTOU window where the WP reads alive but the underlying SP is already gone. Switched to `self.lock()` and using the locked SP for the rest of the closure. Same shape as the GLTexture fix.

Tiny diff but the race is real on shutdown.
