### PR TITLE
palette/config: log expected path when no config file is found

### DIFF
--- a/src/palette/ConfigManager.cpp
+++ b/src/palette/ConfigManager.cpp
@@ -48,6 +48,9 @@ CConfigManager::CConfigManager() : m_inotifyFd(inotify_init()) {
     const auto CFGPATH = Hyprutils::Path::findConfig("hyprtoolkit").first.value_or("");
     m_configPath       = CFGPATH;
 
+    if (CFGPATH.empty())
+        g_logger->log(HT_LOG_DEBUG, "CConfigManager: no hyprtoolkit.conf found, using defaults (expected at $XDG_CONFIG_HOME/hypr/hyprtoolkit.conf or ~/.config/hypr/hyprtoolkit.conf)");
+
     m_config = makeUnique<Hyprlang::CConfig>(CFGPATH.c_str(), Hyprlang::SConfigOptions{.allowMissingConfig = true});
 
     m_config->addConfigValue("background", Hyprlang::INT{0xFF181818});


### PR DESCRIPTION
Closes #41.

`Hyprutils::Path::findConfig("hyprtoolkit")` returns empty silently if `~/.config/hypr` doesn't exist, and people were confused why their themes never loaded. One info-level log saying where it looked. No file is created automatically.
