### PR TITLE
window/popup: log unsupported nested popup attempts

### DIFF
--- a/src/window/WaylandPopup.cpp
+++ b/src/window/WaylandPopup.cpp
@@ -139,5 +139,7 @@ void CWaylandPopup::close() {
 }
 
 SP<IWindow> CWaylandPopup::openPopup(const SWindowCreationData& data) {
-    return nullptr; //FIXME:
+    // nested popups (popup-on-popup) are not implemented
+    g_logger->log(HT_LOG_WARNING, "CWaylandPopup::openPopup: nested popups are not supported");
+    return nullptr;
 }


### PR DESCRIPTION
`CWaylandPopup::openPopup` returned `nullptr` silently. Added a one-line warn so callers notice instead of getting a mute null. Not implementing nested popups in this PR.
