### PR TITLE
treewide: replace empty ctor bodies with = default

### DIFF
--- a/include/hyprtoolkit/palette/Color.hpp
+++ b/include/hyprtoolkit/palette/Color.hpp
@@ -6,7 +6,7 @@
 namespace Hyprtoolkit {
     class CHyprColor {
       public:
-        CHyprColor();
+        CHyprColor() = default;
         CHyprColor(float r, float g, float b, float a = 1.F);
         CHyprColor(const Hyprgraphics::CColor& col, float a);
         CHyprColor(uint64_t);

--- a/src/palette/Color.cpp
+++ b/src/palette/Color.cpp
@@ -11,10 +11,6 @@ using namespace Hyprutils::Memory;
 #define GREEN(c) ((double)(((c) >> 8) & 0xff) / 255.0)
 #define BLUE(c)  ((double)(((c)) & 0xff) / 255.0)
 
-CHyprColor::CHyprColor() {
-    ;
-}
-
 CHyprColor::CHyprColor(float r_, float g_, float b_, float a_) : r(r_), g(g_), b(b_), a(a_) {
     okLab = Hyprgraphics::CColor(Hyprgraphics::CColor::SSRGB{.r = r, .g = g, .b = b}).asOkLab();
 }

--- a/src/renderer/gl/Framebuffer.cpp
+++ b/src/renderer/gl/Framebuffer.cpp
@@ -11,10 +11,6 @@
 
 using namespace Hyprtoolkit;
 
-CFramebuffer::CFramebuffer() {
-    ;
-}
-
 bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     bool firstAlloc = false;
     RASSERT((w > 0 && h > 0), "cannot alloc a FB with negative / zero size! (attempted {}x{})", w, h);

--- a/src/renderer/gl/Framebuffer.hpp
+++ b/src/renderer/gl/Framebuffer.hpp
@@ -6,7 +6,7 @@ namespace Hyprtoolkit {
 
     class CFramebuffer {
       public:
-        CFramebuffer();
+        CFramebuffer() = default;
         ~CFramebuffer();
 
         bool                      alloc(int w, int h, uint32_t format = GL_RGBA);

--- a/src/system/Icons.hpp
+++ b/src/system/Icons.hpp
@@ -11,7 +11,7 @@ namespace Hyprtoolkit {
     class CSystemIconDescription : public ISystemIconDescription {
       public:
         // invalid icon
-        CSystemIconDescription();
+        CSystemIconDescription() = default;
         // lookup icon
         CSystemIconDescription(const std::string& name);
         virtual ~CSystemIconDescription() = default;

--- a/src/system/SystemIcon.cpp
+++ b/src/system/SystemIcon.cpp
@@ -5,10 +5,6 @@
 
 using namespace Hyprtoolkit;
 
-CSystemIconDescription::CSystemIconDescription() {
-    ;
-}
-
 CSystemIconDescription::CSystemIconDescription(const std::string& name) {
     if (g_iconFactory->m_lookupPaths.empty() || name.empty())
         return;


### PR DESCRIPTION
= default the empty CHyprColor, CFramebuffer, and CSystemIconDescription default ctors. No behavior change.