### PR TITLE
window/wayland: initialize appliedScale member

### DIFF
--- a/src/window/IWaylandWindow.hpp
+++ b/src/window/IWaylandWindow.hpp
@@ -85,7 +85,7 @@ namespace Hyprtoolkit {
 
             Hyprutils::Math::Vector2D               size;
             Hyprutils::Math::Vector2D               logicalSize;
-            float                                   appliedScale;
+            float                                   appliedScale = 1.F;
             SP<CCWpFractionalScaleV1>               fractional = nullptr;
             SP<CCWpViewport>                        viewport   = nullptr;
             uint32_t                                serial     = 0;


### PR DESCRIPTION
appliedScale was uninitialized. reading it before the first fractional-scale event would be UB. initialize to 1.F.