### PR TITLE
element/progressbar: add ProgressBar widget

### DIFF
--- a/include/hyprtoolkit/element/ProgressBar.hpp
+++ b/include/hyprtoolkit/element/ProgressBar.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "Element.hpp"
+#include "../types/SizeType.hpp"
+
+#include <hyprutils/memory/UniquePtr.hpp>
+
+namespace Hyprtoolkit {
+
+    struct SProgressBarImpl;
+    struct SProgressBarData;
+    class CProgressBarElement;
+
+    class CProgressBarBuilder {
+      public:
+        ~CProgressBarBuilder() = default;
+
+        static Hyprutils::Memory::CSharedPointer<CProgressBarBuilder> begin();
+
+        // 0.0 - 1.0 (clamped). ignored when indeterminate is true.
+        Hyprutils::Memory::CSharedPointer<CProgressBarBuilder>        value(float);
+
+        // when true, the bar shows a looping pulse instead of value-driven fill
+        Hyprutils::Memory::CSharedPointer<CProgressBarBuilder>        indeterminate(bool);
+
+        Hyprutils::Memory::CSharedPointer<CProgressBarBuilder>        size(CDynamicSize&&);
+
+        Hyprutils::Memory::CSharedPointer<CProgressBarElement>        commence();
+
+      private:
+        Hyprutils::Memory::CWeakPointer<CProgressBarBuilder> m_self;
+        Hyprutils::Memory::CUniquePointer<SProgressBarData>  m_data;
+        Hyprutils::Memory::CWeakPointer<CProgressBarElement> m_element;
+
+        CProgressBarBuilder() = default;
+
+        friend class CProgressBarElement;
+    };
+
+    class CProgressBarElement : public IElement {
+      public:
+        virtual ~CProgressBarElement() = default;
+
+        Hyprutils::Memory::CSharedPointer<CProgressBarBuilder> rebuild();
+        virtual Hyprutils::Math::Vector2D                      size();
+
+        // imperative updates that skip the builder allocation
+        float                                                  value();
+        void                                                   setValue(float);
+
+      private:
+        CProgressBarElement(const SProgressBarData& data);
+        static Hyprutils::Memory::CSharedPointer<CProgressBarElement> create(const SProgressBarData& data);
+
+        void                                                          replaceData(const SProgressBarData& data);
+
+        virtual void                                                  paint();
+        virtual void                                                  reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize = {-1, -1});
+        virtual std::optional<Hyprutils::Math::Vector2D>              preferredSize(const Hyprutils::Math::Vector2D& parent);
+        virtual std::optional<Hyprutils::Math::Vector2D>              minimumSize(const Hyprutils::Math::Vector2D& parent);
+        virtual std::optional<Hyprutils::Math::Vector2D>              maximumSize(const Hyprutils::Math::Vector2D& parent);
+        virtual bool                                                  positioningDependsOnChild();
+
+        Hyprutils::Memory::CUniquePointer<SProgressBarImpl>           m_impl;
+
+        friend class CProgressBarBuilder;
+    };
+};

--- a/src/core/AnimationManager.cpp
+++ b/src/core/AnimationManager.cpp
@@ -12,8 +12,10 @@ CHTAnimationManager::CHTAnimationManager() {
     m_animationTree.createNode("global");
 
     m_animationTree.createNode("fast", "global");
+    m_animationTree.createNode("indeterminate", "global");
 
     m_animationTree.setConfigForNode("fast", 1, 3.3F, "easeOutQuint");
+    m_animationTree.setConfigForNode("indeterminate", 1, 0.7F, "linear");
 }
 
 template <Animable VarType>

--- a/src/element/progressBar/Builder.cpp
+++ b/src/element/progressBar/Builder.cpp
@@ -1,0 +1,34 @@
+#include "ProgressBar.hpp"
+
+using namespace Hyprtoolkit;
+
+SP<CProgressBarBuilder> CProgressBarBuilder::begin() {
+    SP<CProgressBarBuilder> p = SP<CProgressBarBuilder>(new CProgressBarBuilder());
+    p->m_data                 = makeUnique<SProgressBarData>();
+    p->m_self                 = p;
+    return p;
+}
+
+SP<CProgressBarBuilder> CProgressBarBuilder::value(float v) {
+    m_data->value = v;
+    return m_self.lock();
+}
+
+SP<CProgressBarBuilder> CProgressBarBuilder::indeterminate(bool v) {
+    m_data->indeterminate = v;
+    return m_self.lock();
+}
+
+SP<CProgressBarBuilder> CProgressBarBuilder::size(CDynamicSize&& s) {
+    m_data->size = std::move(s);
+    return m_self.lock();
+}
+
+SP<CProgressBarElement> CProgressBarBuilder::commence() {
+    if (m_element) {
+        m_element->replaceData(*m_data);
+        return m_element.lock();
+    }
+
+    return CProgressBarElement::create(*m_data);
+}

--- a/src/element/progressBar/ProgressBar.cpp
+++ b/src/element/progressBar/ProgressBar.cpp
@@ -1,0 +1,164 @@
+#include "ProgressBar.hpp"
+
+#include <hyprtoolkit/palette/Palette.hpp>
+#include <algorithm>
+
+#include "../../core/AnimationManager.hpp"
+#include "../../core/InternalBackend.hpp"
+#include "../../layout/Positioner.hpp"
+#include "../../window/ToolkitWindow.hpp"
+#include "../Element.hpp"
+
+using namespace Hyprtoolkit;
+using namespace Hyprutils::Math;
+using CBAV = Hyprutils::Animation::CBaseAnimatedVariable;
+
+SP<CProgressBarElement> CProgressBarElement::create(const SProgressBarData& data) {
+    auto p          = SP<CProgressBarElement>(new CProgressBarElement(data));
+    p->impl->self   = p;
+    p->m_impl->self = p;
+    return p;
+}
+
+CProgressBarElement::CProgressBarElement(const SProgressBarData& data) : IElement(), m_impl(makeUnique<SProgressBarImpl>()) {
+    m_impl->data = data;
+
+    m_impl->background = CRectangleBuilder::begin()
+                             ->color([] { return g_palette->m_colors.base; })
+                             ->rounding(g_palette->m_vars.smallRounding)
+                             ->borderColor([] { return g_palette->m_colors.alternateBase; })
+                             ->borderThickness(1)
+                             ->size(CDynamicSize{CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
+                             ->commence();
+
+    m_impl->background->setPositionMode(HT_POSITION_ABSOLUTE);
+
+    const float W = m_impl->data.indeterminate ? PROGRESSBAR_PULSE_WIDTH : std::clamp(m_impl->data.value, 0.F, 1.F);
+
+    m_impl->foreground = CRectangleBuilder::begin()
+                             ->color([] { return g_palette->m_colors.accent; })
+                             ->rounding(g_palette->m_vars.smallRounding)
+                             ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {W, 1.F}})
+                             ->commence();
+
+    m_impl->background->addChild(m_impl->foreground);
+    addChild(m_impl->background);
+
+    impl->grouped = true;
+
+    if (m_impl->data.indeterminate)
+        m_impl->startIndeterminate();
+}
+
+void SProgressBarImpl::applyValue() {
+    const float W = std::clamp(data.value, 0.F, 1.F);
+    foreground->rebuild()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {W, 1.F}})->commence();
+}
+
+void SProgressBarImpl::startIndeterminate() {
+    if (phase)
+        return;
+
+    foreground->setPositionMode(IElement::HT_POSITION_ABSOLUTE);
+
+    g_animationManager->createAnimation(0.F, phase, g_animationManager->m_animationTree.getConfig("indeterminate"));
+
+    phase->setUpdateCallback([this](WP<CBAV>) { onPulseTick(); });
+    phase->setCallbackOnEnd(
+        [this](WP<CBAV>) {
+            phase->setValueAndWarp(0.F);
+            *phase = 1.F;
+        },
+        false);
+
+    *phase = 1.F;
+}
+
+void SProgressBarImpl::stopIndeterminate() {
+    if (!phase)
+        return;
+    phase->resetAllCallbacks();
+    phase.reset();
+
+    foreground->setPositionMode(IElement::HT_POSITION_AUTO);
+    foreground->rebuild()
+        ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {std::clamp(data.value, 0.F, 1.F), 1.F}})
+        ->commence();
+}
+
+void SProgressBarImpl::onPulseTick() {
+    const float bgW = background->size().x;
+    if (bgW <= 0.F)
+        return;
+    const float pulseW = bgW * PROGRESSBAR_PULSE_WIDTH;
+    const float t      = phase->value();
+    const float x      = t * (bgW + pulseW) - pulseW;
+    foreground->setAbsolutePosition({x, 0.0});
+}
+
+void CProgressBarElement::paint() {
+    ;
+}
+
+void CProgressBarElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize) {
+    IElement::reposition(box);
+    g_positioner->positionChildren(impl->self.lock());
+}
+
+SP<CProgressBarBuilder> CProgressBarElement::rebuild() {
+    auto p       = SP<CProgressBarBuilder>(new CProgressBarBuilder());
+    p->m_self    = p;
+    p->m_data    = makeUnique<SProgressBarData>(m_impl->data);
+    p->m_element = m_impl->self;
+    return p;
+}
+
+void CProgressBarElement::replaceData(const SProgressBarData& data) {
+    const bool VALUE_CHANGED = data.value != m_impl->data.value;
+    const bool INDET_CHANGED = data.indeterminate != m_impl->data.indeterminate;
+
+    m_impl->data = data;
+
+    if (INDET_CHANGED) {
+        if (m_impl->data.indeterminate)
+            m_impl->startIndeterminate();
+        else
+            m_impl->stopIndeterminate();
+    } else if (VALUE_CHANGED && !m_impl->data.indeterminate)
+        m_impl->applyValue();
+
+    if (impl->window)
+        impl->window->scheduleReposition(impl->self);
+}
+
+float CProgressBarElement::value() {
+    return m_impl->data.value;
+}
+
+void CProgressBarElement::setValue(float v) {
+    if (v == m_impl->data.value)
+        return;
+    m_impl->data.value = v;
+    if (!m_impl->data.indeterminate)
+        m_impl->applyValue();
+}
+
+Hyprutils::Math::Vector2D CProgressBarElement::size() {
+    return impl->position.size();
+}
+
+std::optional<Vector2D> CProgressBarElement::preferredSize(const Hyprutils::Math::Vector2D& parent) {
+    return m_impl->data.size.calculate(parent);
+}
+
+std::optional<Vector2D> CProgressBarElement::minimumSize(const Hyprutils::Math::Vector2D& parent) {
+    return m_impl->data.size.calculate(parent);
+}
+
+std::optional<Vector2D> CProgressBarElement::maximumSize(const Hyprutils::Math::Vector2D& parent) {
+    return m_impl->data.size.calculate(parent);
+}
+
+bool CProgressBarElement::positioningDependsOnChild() {
+    return m_impl->data.size.hasAuto();
+}

--- a/src/element/progressBar/ProgressBar.hpp
+++ b/src/element/progressBar/ProgressBar.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <hyprtoolkit/element/ProgressBar.hpp>
+#include <hyprtoolkit/element/Rectangle.hpp>
+#include <hyprtoolkit/element/Null.hpp>
+
+#include "../../core/AnimatedVariable.hpp"
+#include "../../helpers/Memory.hpp"
+
+namespace Hyprtoolkit {
+
+    struct SProgressBarData {
+        float        value         = 0.F;
+        bool         indeterminate = false;
+        CDynamicSize size{CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_ABSOLUTE, {1.F, 16.F}};
+    };
+
+    // pulse rectangle width as a fraction of the bar
+    static constexpr float PROGRESSBAR_PULSE_WIDTH = 0.3F;
+
+    struct SProgressBarImpl {
+        SProgressBarData        data;
+
+        WP<CProgressBarElement> self;
+
+        SP<CRectangleElement>   background;
+        SP<CRectangleElement>   foreground;
+
+        // 0..1 cycling phase used for the indeterminate pulse
+        PHLANIMVAR<float>       phase;
+
+        void                    applyValue();
+        void                    startIndeterminate();
+        void                    stopIndeterminate();
+        void                    onPulseTick();
+    };
+}

--- a/tests/Controls.cpp
+++ b/tests/Controls.cpp
@@ -10,6 +10,7 @@
 #include <hyprtoolkit/element/Null.hpp>
 #include <hyprtoolkit/element/Checkbox.hpp>
 #include <hyprtoolkit/element/Spinbox.hpp>
+#include <hyprtoolkit/element/ProgressBar.hpp>
 #include <hyprtoolkit/element/Slider.hpp>
 #include <hyprtoolkit/element/ScrollArea.hpp>
 #include <hyprtoolkit/element/Combobox.hpp>
@@ -200,6 +201,9 @@ int main(int argc, char** argv, char** envp) {
     auto slider2 = stretchLayout(
         "Big Slider", CSliderBuilder::begin()->max(10000)->val(2500)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_ABSOLUTE, {0.5F, SLIDER_HEIGHT}})->commence());
 
+    auto progress = stretchLayout(
+        "Progress", CProgressBarBuilder::begin()->value(0.42F)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_ABSOLUTE, {0.5F, 14.F}})->commence());
+
     auto combo = stretchLayout(
         "Combo",
         CComboboxBuilder::begin()
@@ -242,6 +246,7 @@ int main(int argc, char** argv, char** envp) {
     mainLayout->addChild(spinbox);
     mainLayout->addChild(slider);
     mainLayout->addChild(slider2);
+    mainLayout->addChild(progress);
     mainLayout->addChild(combo);
     mainLayout->addChild(textboxCont);
     mainLayout->addChild(text);


### PR DESCRIPTION
horizontal progress bar. determinate mode renders a filled foreground at value*width, indeterminate mode runs a looping pulse driven by the animation manager. setValue() is a no-op on the visual while indeterminate is set, matching replaceData().