### PR TITLE
element/radiogroup: add Radio style and coordinator

### DIFF
--- a/include/hyprtoolkit/element/Checkbox.hpp
+++ b/include/hyprtoolkit/element/Checkbox.hpp
@@ -14,6 +14,11 @@ namespace Hyprtoolkit {
     struct SCheckboxData;
     class CCheckboxElement;
 
+    enum eCheckboxStyle : uint8_t {
+        HT_CHECKBOX_STYLE_CHECKMARK = 0,
+        HT_CHECKBOX_STYLE_RADIO,
+    };
+
     class CCheckboxBuilder {
       public:
         ~CCheckboxBuilder() = default;
@@ -21,6 +26,7 @@ namespace Hyprtoolkit {
         static Hyprutils::Memory::CSharedPointer<CCheckboxBuilder> begin();
         Hyprutils::Memory::CSharedPointer<CCheckboxBuilder>        onToggled(std::function<void(Hyprutils::Memory::CSharedPointer<CCheckboxElement>, bool)>&&);
         Hyprutils::Memory::CSharedPointer<CCheckboxBuilder>        toggled(bool);
+        Hyprutils::Memory::CSharedPointer<CCheckboxBuilder>        style(eCheckboxStyle);
         Hyprutils::Memory::CSharedPointer<CCheckboxBuilder>        size(CDynamicSize&&);
 
         Hyprutils::Memory::CSharedPointer<CCheckboxElement>        commence();
@@ -62,5 +68,6 @@ namespace Hyprtoolkit {
         Hyprutils::Memory::CUniquePointer<SCheckboxImpl>           m_impl;
 
         friend class CCheckboxBuilder;
+        friend class CRadioGroup;
     };
 };

--- a/include/hyprtoolkit/element/RadioGroup.hpp
+++ b/include/hyprtoolkit/element/RadioGroup.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Checkbox.hpp"
+
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <hyprutils/memory/WeakPtr.hpp>
+
+#include <functional>
+#include <vector>
+
+namespace Hyprtoolkit {
+
+    // Coordinates exclusivity across a set of radio-styled CCheckboxElements.
+    // Layout and sizing are left to the caller; the group only enforces that
+    // toggling one radio on turns the others off.
+    class CRadioGroup {
+      public:
+        static Hyprutils::Memory::CSharedPointer<CRadioGroup> create();
+        ~CRadioGroup()                                        = default;
+
+        void                                                  add(Hyprutils::Memory::CSharedPointer<CCheckboxElement> radio);
+        Hyprutils::Memory::CSharedPointer<CCheckboxElement>   selected();
+        void                                                  setSelected(Hyprutils::Memory::CSharedPointer<CCheckboxElement> radio);
+        void                                                  onSelected(std::function<void(Hyprutils::Memory::CSharedPointer<CCheckboxElement>)>&&);
+
+      private:
+        CRadioGroup() = default;
+
+        std::vector<Hyprutils::Memory::CWeakPointer<CCheckboxElement>>      m_radios;
+        std::function<void(Hyprutils::Memory::CSharedPointer<CCheckboxElement>)> m_onSelected;
+        Hyprutils::Memory::CWeakPointer<CRadioGroup>                        m_self;
+    };
+};

--- a/src/element/checkbox/Builder.cpp
+++ b/src/element/checkbox/Builder.cpp
@@ -19,6 +19,11 @@ SP<CCheckboxBuilder> CCheckboxBuilder::toggled(bool x) {
     return m_self.lock();
 }
 
+SP<CCheckboxBuilder> CCheckboxBuilder::style(eCheckboxStyle s) {
+    m_data->style = s;
+    return m_self.lock();
+}
+
 SP<CCheckboxBuilder> CCheckboxBuilder::size(CDynamicSize&& s) {
     m_data->size = std::move(s);
     return m_self.lock();

--- a/src/element/checkbox/Checkbox.cpp
+++ b/src/element/checkbox/Checkbox.cpp
@@ -116,6 +116,22 @@ void CCheckboxElement::replaceData(const SCheckboxData& data) {
         impl->window->scheduleReposition(impl->self);
 }
 
+bool CCheckboxElement::state() {
+    return m_impl->data.toggled;
+}
+
+void CCheckboxElement::setState(bool state) {
+    if (m_impl->data.toggled == state)
+        return;
+
+    m_impl->data.toggled = state;
+
+    m_impl->foreground->recheckColor();
+
+    if (impl->window)
+        impl->window->scheduleReposition(impl->self);
+}
+
 Hyprutils::Math::Vector2D CCheckboxElement::size() {
     return impl->position.size();
 }

--- a/src/element/checkbox/Checkbox.cpp
+++ b/src/element/checkbox/Checkbox.cpp
@@ -22,9 +22,12 @@ SP<CCheckboxElement> CCheckboxElement::create(const SCheckboxData& data) {
 CCheckboxElement::CCheckboxElement(const SCheckboxData& data) : IElement(), m_impl(makeUnique<SCheckboxImpl>()) {
     m_impl->data = data;
 
+    const bool RADIO    = data.style == HT_CHECKBOX_STYLE_RADIO;
+    const int  ROUNDING = RADIO ? 7 : g_palette->m_vars.smallRounding;
+
     m_impl->background = CRectangleBuilder::begin()
                              ->color([] { return g_palette->m_colors.base; })
-                             ->rounding(g_palette->m_vars.smallRounding)
+                             ->rounding(ROUNDING)
                              ->borderColor([] { return g_palette->m_colors.alternateBase; })
                              ->borderThickness(1)
                              ->size(CDynamicSize{CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {14.F, 14.F}})
@@ -33,17 +36,28 @@ CCheckboxElement::CCheckboxElement(const SCheckboxData& data) : IElement(), m_im
     m_impl->background->setPositionMode(HT_POSITION_ABSOLUTE);
     m_impl->background->setPositionFlag(HT_POSITION_FLAG_CENTER, true);
 
-    m_impl->foreground = CCheckmarkElement::create(SCheckmarkData{
-        .size  = {CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}},
-        .color = [impl = m_impl.get()] {
-            auto c = g_palette->m_colors.accent;
-            c.a    = impl->data.toggled ? 1.F : 0.F;
-            return c;
-        },
-    });
+    auto fgColor = [impl = m_impl.get()] {
+        auto c = g_palette->m_colors.accent;
+        c.a    = impl->data.toggled ? 1.F : 0.F;
+        return c;
+    };
 
-    m_impl->foreground->setPositionMode(HT_POSITION_ABSOLUTE);
-    m_impl->foreground->setPositionFlag(HT_POSITION_FLAG_CENTER, true);
+    if (RADIO) {
+        m_impl->foreground = CRectangleBuilder::begin()
+                                 ->color(fgColor)
+                                 ->rounding(4)
+                                 ->size(CDynamicSize{CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {8.F, 8.F}})
+                                 ->commence();
+        m_impl->foreground->setPositionMode(HT_POSITION_ABSOLUTE);
+        m_impl->foreground->setPositionFlag(HT_POSITION_FLAG_CENTER, true);
+    } else {
+        m_impl->foreground = CCheckmarkElement::create(SCheckmarkData{
+            .size  = {CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}},
+            .color = fgColor,
+        });
+        m_impl->foreground->setPositionMode(HT_POSITION_ABSOLUTE);
+        m_impl->foreground->setPositionFlag(HT_POSITION_FLAG_CENTER, true);
+    }
 
     m_impl->background->addChild(m_impl->foreground);
 
@@ -77,6 +91,10 @@ CCheckboxElement::CCheckboxElement(const SCheckboxData& data) : IElement(), m_im
             return;
 
         if (button == Input::MOUSE_BUTTON_LEFT) {
+            // a radio is turned off by selecting another, never by clicking itself
+            if (m_impl->data.style == HT_CHECKBOX_STYLE_RADIO && m_impl->data.toggled)
+                return;
+
             m_impl->data.toggled = !m_impl->data.toggled;
 
             if (m_impl->data.onToggled)

--- a/src/element/checkbox/Checkbox.cpp
+++ b/src/element/checkbox/Checkbox.cpp
@@ -46,7 +46,7 @@ CCheckboxElement::CCheckboxElement(const SCheckboxData& data) : IElement(), m_im
         m_impl->foreground = CRectangleBuilder::begin()
                                  ->color(fgColor)
                                  ->rounding(4)
-                                 ->size(CDynamicSize{CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {8.F, 8.F}})
+                                 ->size(CDynamicSize{CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {4.F / 7.F, 4.F / 7.F}})
                                  ->commence();
         m_impl->foreground->setPositionMode(HT_POSITION_ABSOLUTE);
         m_impl->foreground->setPositionFlag(HT_POSITION_FLAG_CENTER, true);

--- a/src/element/checkbox/Checkbox.hpp
+++ b/src/element/checkbox/Checkbox.hpp
@@ -40,16 +40,17 @@ namespace Hyprtoolkit {
 
     struct SCheckboxData {
         bool                                                                           toggled = false;
+        eCheckboxStyle                                                                 style   = HT_CHECKBOX_STYLE_CHECKMARK;
         std::function<void(Hyprutils::Memory::CSharedPointer<CCheckboxElement>, bool)> onToggled;
         CDynamicSize                                                                   size{CDynamicSize::HT_SIZE_AUTO, CDynamicSize::HT_SIZE_AUTO, {}};
     };
 
     struct SCheckboxImpl {
-        SCheckboxData               data;
+        SCheckboxData         data;
 
-        WP<CCheckboxElement>        self;
-        SP<CRectangleElement>       background;
-        SP<CCheckmarkElement>       foreground;
+        WP<CCheckboxElement>  self;
+        SP<CRectangleElement> background;
+        SP<IElement>          foreground;
 
         bool                        labelChanged = true;
 

--- a/src/element/radioGroup/RadioGroup.cpp
+++ b/src/element/radioGroup/RadioGroup.cpp
@@ -1,0 +1,67 @@
+#include <hyprtoolkit/element/RadioGroup.hpp>
+
+#include "../checkbox/Checkbox.hpp"
+
+using namespace Hyprtoolkit;
+using namespace Hyprutils::Memory;
+
+SP<CRadioGroup> CRadioGroup::create() {
+    auto p    = SP<CRadioGroup>(new CRadioGroup());
+    p->m_self = p;
+    return p;
+}
+
+void CRadioGroup::add(SP<CCheckboxElement> radio) {
+    if (!radio)
+        return;
+
+    // wrap any existing onToggled so the user's callback still fires, and
+    // tack on the exclusivity + group-level notification afterwards.
+    auto userCb = std::move(radio->m_impl->data.onToggled);
+
+    radio->m_impl->data.onToggled = [userCb = std::move(userCb), groupWp = m_self](SP<CCheckboxElement> elem, bool on) {
+        if (userCb)
+            userCb(elem, on);
+
+        auto group = groupWp.lock();
+        if (!group || !on)
+            return;
+
+        for (const auto& wp : group->m_radios) {
+            auto other = wp.lock();
+            if (!other || other == elem)
+                continue;
+            other->setState(false);
+        }
+
+        if (group->m_onSelected)
+            group->m_onSelected(elem);
+    };
+
+    m_radios.emplace_back(radio);
+}
+
+SP<CCheckboxElement> CRadioGroup::selected() {
+    for (const auto& wp : m_radios) {
+        auto p = wp.lock();
+        if (p && p->state())
+            return p;
+    }
+    return nullptr;
+}
+
+void CRadioGroup::setSelected(SP<CCheckboxElement> radio) {
+    for (const auto& wp : m_radios) {
+        auto p = wp.lock();
+        if (!p)
+            continue;
+        p->setState(p == radio);
+    }
+
+    if (m_onSelected && radio)
+        m_onSelected(radio);
+}
+
+void CRadioGroup::onSelected(std::function<void(SP<CCheckboxElement>)>&& fn) {
+    m_onSelected = std::move(fn);
+}

--- a/src/layout/Positioner.cpp
+++ b/src/layout/Positioner.cpp
@@ -1,5 +1,7 @@
 #include "Positioner.hpp"
 
+#include <cmath>
+
 #include "../element/Element.hpp"
 #include "../window/ToolkitWindow.hpp"
 
@@ -63,9 +65,9 @@ void CPositioner::positionChildren(SP<IElement> element, const SRepositionData& 
             }
 
             if (c->impl->positionFlags & IElement::HT_POSITION_FLAG_HCENTER)
-                itemBox.translate(Vector2D{((BOX.size() - itemBox.size()) / 2.F).x, 0.F});
+                itemBox.translate(Vector2D{std::round(((BOX.size() - itemBox.size()) / 2.F).x), 0.F});
             if (c->impl->positionFlags & IElement::HT_POSITION_FLAG_VCENTER)
-                itemBox.translate(Vector2D{0.F, ((BOX.size() - itemBox.size()) / 2.F).y});
+                itemBox.translate(Vector2D{0.F, std::round(((BOX.size() - itemBox.size()) / 2.F).y)});
 
             itemBox.translate(c->impl->absoluteOffset);
         }

--- a/tests/Controls.cpp
+++ b/tests/Controls.cpp
@@ -9,6 +9,7 @@
 #include <hyprtoolkit/element/Button.hpp>
 #include <hyprtoolkit/element/Null.hpp>
 #include <hyprtoolkit/element/Checkbox.hpp>
+#include <hyprtoolkit/element/RadioGroup.hpp>
 #include <hyprtoolkit/element/Spinbox.hpp>
 #include <hyprtoolkit/element/ProgressBar.hpp>
 #include <hyprtoolkit/element/Slider.hpp>
@@ -189,6 +190,23 @@ int main(int argc, char** argv, char** envp) {
     auto checkbox  = stretchLayout("checkbox 1", CCheckboxBuilder::begin()->commence());
     auto checkbox2 = stretchLayout("checkbox 2", CCheckboxBuilder::begin()->commence());
 
+    auto radio1 = CCheckboxBuilder::begin()->style(HT_CHECKBOX_STYLE_RADIO)->toggled(true)->commence();
+    auto radio2 = CCheckboxBuilder::begin()->style(HT_CHECKBOX_STYLE_RADIO)->commence();
+    auto radio3 = CCheckboxBuilder::begin()->style(HT_CHECKBOX_STYLE_RADIO)->commence();
+
+    auto radioGroup = CRadioGroup::create();
+    radioGroup->add(radio1);
+    radioGroup->add(radio2);
+    radioGroup->add(radio3);
+
+    auto radioRow = CRowLayoutBuilder::begin()->gap(8)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_AUTO, {1, 1}})->commence();
+    radioRow->addChild(radio1);
+    radioRow->addChild(CTextBuilder::begin()->text("first")->color([] { return backend->getPalette()->m_colors.text; })->commence());
+    radioRow->addChild(radio2);
+    radioRow->addChild(CTextBuilder::begin()->text("second")->color([] { return backend->getPalette()->m_colors.text; })->commence());
+    radioRow->addChild(radio3);
+    radioRow->addChild(CTextBuilder::begin()->text("third")->color([] { return backend->getPalette()->m_colors.text; })->commence());
+
     auto spinbox = CSpinboxBuilder::begin()
                        ->label("Spinbox")
                        ->items({"Hello", "World", "Amongus"})
@@ -243,6 +261,7 @@ int main(int argc, char** argv, char** envp) {
     mainLayout->addChild(button4);
     mainLayout->addChild(checkbox);
     mainLayout->addChild(checkbox2);
+    mainLayout->addChild(radioRow);
     mainLayout->addChild(spinbox);
     mainLayout->addChild(slider);
     mainLayout->addChild(slider2);


### PR DESCRIPTION
CCheckboxElement gains a style enum with HT_CHECKBOX_STYLE_RADIO, rendering a circular dot and refusing to toggle itself off. CRadioGroup is a thin coordinator with create/add/setSelected/onSelected; it wraps each radio onToggled to enforce exclusivity without imposing a layout. stacked on #69 and #73.