### PR TITLE
internal: fix include for NAME_MAX climits->linux/limits.h

### DIFF
--- a/src/palette/ConfigManager.cpp
+++ b/src/palette/ConfigManager.cpp
@@ -8,7 +8,7 @@
 #include <glob.h>
 #include <filesystem>
 #include <cstring>
-#include <climits>
+#include <linux/limits.h>
 
 using namespace Hyprtoolkit;
 


### PR DESCRIPTION
Adjusts the fix from #38 as `climits` does not define `NAME_MAX`, but `linux/limits.h` does.
The previous fix is fragil, as the standardlibrary only accidentally included `linux/limits.h` but that can change with a compiler update.

Originally the project started failing on `gentoo` after upgrading to `gcc-16`.
Related: https://codeberg.org/hyproverlay/hyproverlay/issues/64