### PR TITLE
core/backend: reset g_backend last in terminate to fix UAF

### DIFF
--- a/src/core/Backend.cpp
+++ b/src/core/Backend.cpp
@@ -228,8 +228,8 @@ void CBackend::terminate() {
         g_iconFactory.reset();
         g_config.reset();
         g_palette.reset();
-        g_backend.reset();
         g_logger.reset();
+        g_backend.reset();
     }
 }
 
@@ -544,7 +544,6 @@ void CBackend::enterLoop() {
     g_animationManager.reset();
 
     g_palette.reset();
-    g_backend.reset();
     g_logger.reset();
 
     m_sLoopState.idleEvent = true;
@@ -554,6 +553,10 @@ void CBackend::enterLoop() {
     m_sLoopState.timerCV.notify_all();
 
     write(m_sLoopState.exitfd[1], "hello", 5);
+
+    // reset g_backend last: if this is the final strong reference, *this is
+    // destroyed here, no member access may follow this line in this scope.
+    g_backend.reset();
 
     if (timersThr.joinable())
         timersThr.join();


### PR DESCRIPTION
In the threaded path, g_backend.reset() appeared before idleCV.notify_all(),
timerCV.notify_all(), and write(exitfd[1], ...). If g_backend held the last
strong reference at that point, *this was destroyed mid-function and the
subsequent member accesses were UAF.

Fix: reset g_backend last in both the threaded and non-threaded paths of
terminate(). Builds on the atexit-based fix from #51.

Closes hyprwm/hyprtoolkit#37.