### PR TITLE
core/animation: implement gradient animation

### DIFF
--- a/include/hyprtoolkit/element/Rectangle.hpp
+++ b/include/hyprtoolkit/element/Rectangle.hpp
@@ -3,6 +3,7 @@
 #include "Element.hpp"
 #include "../types/SizeType.hpp"
 #include "../palette/Color.hpp"
+#include "../palette/Gradient.hpp"
 
 #include <hyprutils/memory/UniquePtr.hpp>
 
@@ -19,6 +20,7 @@ namespace Hyprtoolkit {
         static Hyprutils::Memory::CSharedPointer<CRectangleBuilder> begin();
         Hyprutils::Memory::CSharedPointer<CRectangleBuilder>        color(colorFn&&);
         Hyprutils::Memory::CSharedPointer<CRectangleBuilder>        borderColor(colorFn&&);
+        Hyprutils::Memory::CSharedPointer<CRectangleBuilder>        borderGradient(gradientFn&&);
         Hyprutils::Memory::CSharedPointer<CRectangleBuilder>        rounding(int);
         Hyprutils::Memory::CSharedPointer<CRectangleBuilder>        borderThickness(int);
         Hyprutils::Memory::CSharedPointer<CRectangleBuilder>        size(CDynamicSize&&);

--- a/include/hyprtoolkit/palette/Gradient.hpp
+++ b/include/hyprtoolkit/palette/Gradient.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Color.hpp"
+
+#include <functional>
+#include <vector>
+
+namespace Hyprtoolkit {
+
+    struct CGradientValueData {
+        std::vector<CHyprColor> m_vColors;
+        float                   m_fAngle = 0.F;
+
+        CGradientValueData() = default;
+        CGradientValueData(const CHyprColor& col) : m_vColors{col} {}
+
+        bool operator==(const CGradientValueData& rhs) const;
+    };
+
+    using gradientFn = std::function<CGradientValueData()>;
+}

--- a/src/core/AnimatedVariable.hpp
+++ b/src/core/AnimatedVariable.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <hyprtoolkit/palette/Color.hpp>
+#include <hyprtoolkit/palette/Gradient.hpp>
 #include <hyprutils/animation/AnimatedVariable.hpp>
 #include <hyprutils/math/Vector2D.hpp>
 
@@ -13,7 +14,7 @@ namespace Hyprtoolkit {
         AVARTYPE_FLOAT,
         AVARTYPE_VECTOR,
         AVARTYPE_COLOR,
-        AVARTYPE_GRADIENT
+        AVARTYPE_GRADIENT,
     };
 
     // Utility to bind a type with its corresponding eAnimatedVarType
@@ -38,11 +39,10 @@ namespace Hyprtoolkit {
         static constexpr eAnimatedVarType value = AVARTYPE_COLOR;
     };
 
-    // TODO:
-    // template <>
-    // struct STypeToAnimatedVarType_t<CGradientValueData> {
-    //     static constexpr eAnimatedVarType value = AVARTYPE_GRADIENT;
-    // };
+    template <>
+    struct STypeToAnimatedVarType_t<CGradientValueData> {
+        static constexpr eAnimatedVarType value = AVARTYPE_GRADIENT;
+    };
 
     template <class T>
     inline constexpr eAnimatedVarType typeToeAnimatedVarType = STypeToAnimatedVarType_t<T>::value;
@@ -55,7 +55,7 @@ namespace Hyprtoolkit {
     // This is mainly to get better errors if we put a type that's not supported
     // Otherwise template errors are ugly
     template <class T>
-    concept Animable = OneOf<T, Hyprutils::Math::Vector2D, float, CHyprColor /*, CGradientValueData*/>;
+    concept Animable = OneOf<T, Hyprutils::Math::Vector2D, float, CHyprColor, CGradientValueData>;
 
     struct SAnimationContext {};
 

--- a/src/core/AnimationManager.cpp
+++ b/src/core/AnimationManager.cpp
@@ -2,6 +2,8 @@
 
 #include "../Macros.hpp"
 
+#include <hyprtoolkit/palette/Gradient.hpp>
+
 using namespace Hyprtoolkit;
 using namespace Hyprutils::Math;
 
@@ -53,39 +55,40 @@ static void updateColorVariable(CAnimatedVariable<CHyprColor>& av, const float P
     av.value() = {lerped, lerp(av.begun().a, av.goal().a, POINTY)};
 }
 
-// void updateGradientVariable(CAnimatedVariable<CGradientValueData>& av, const float POINTY, bool warp = false) {
-//     if (warp || av.value() == av.goal()) {
-//         av.warp(true, false);
-//         return;
-//     }
+static void updateGradientVariable(CAnimatedVariable<CGradientValueData>& av, const float POINTY, bool warp = false) {
+    if (warp || !av.enabled() || av.value() == av.goal()) {
+        av.warp(true, false);
+        return;
+    }
 
-//     av.value().m_vColors.resize(av.goal().m_vColors.size(), av.goal().m_vColors.back());
+    if (av.goal().m_vColors.empty()) {
+        av.warp(true, false);
+        return;
+    }
 
-//     for (size_t i = 0; i < av.value().m_vColors.size(); ++i) {
-//         const CHyprColor&          sourceCol = (i < av.begun().m_vColors.size()) ? av.begun().m_vColors[i] : av.begun().m_vColors.back();
-//         const CHyprColor&          targetCol = (i < av.goal().m_vColors.size()) ? av.goal().m_vColors[i] : av.goal().m_vColors.back();
+    av.value().m_vColors.resize(av.goal().m_vColors.size(), av.goal().m_vColors.back());
 
-//         const auto&                L1 = sourceCol.asOkLab();
-//         const auto&                L2 = targetCol.asOkLab();
+    static const auto lerp = [](const float one, const float two, const float progress) -> float { return one + ((two - one) * progress); };
 
-//         static const auto          lerp = [](const float one, const float two, const float progress) -> float { return one + ((two - one) * progress); };
+    for (size_t i = 0; i < av.value().m_vColors.size(); ++i) {
+        const CHyprColor& sourceCol = (i < av.begun().m_vColors.size()) ? av.begun().m_vColors[i] : av.begun().m_vColors.back();
+        const CHyprColor& targetCol = av.goal().m_vColors[i];
 
-//         const Hyprgraphics::CColor lerped = Hyprgraphics::CColor::SOkLab{
-//             .l = lerp(L1.l, L2.l, POINTY),
-//             .a = lerp(L1.a, L2.a, POINTY),
-//             .b = lerp(L1.b, L2.b, POINTY),
-//         };
+        const auto&                L1 = sourceCol.asOkLab();
+        const auto&                L2 = targetCol.asOkLab();
 
-//         av.value().m_vColors[i] = {lerped, lerp(sourceCol.a, targetCol.a, POINTY)};
-//     }
+        const Hyprgraphics::CColor lerped = Hyprgraphics::CColor::SOkLab{
+            .l = lerp(L1.l, L2.l, POINTY),
+            .a = lerp(L1.a, L2.a, POINTY),
+            .b = lerp(L1.b, L2.b, POINTY),
+        };
 
-//     if (av.begun().m_fAngle != av.goal().m_fAngle) {
-//         const float DELTA   = av.goal().m_fAngle - av.begun().m_fAngle;
-//         av.value().m_fAngle = av.begun().m_fAngle + DELTA * POINTY;
-//     }
+        av.value().m_vColors[i] = {lerped, lerp(sourceCol.a, targetCol.a, POINTY)};
+    }
 
-//     av.value().updateColorsOk();
-// }
+    const float DELTA   = av.goal().m_fAngle - av.begun().m_fAngle;
+    av.value().m_fAngle = av.begun().m_fAngle + DELTA * POINTY;
+}
 
 void CHTAnimationManager::tick() {
     for (const auto& PAV : m_vActiveAnimatedVariables) {
@@ -113,11 +116,11 @@ void CHTAnimationManager::tick() {
                 RASSERT(pTypedAV, "Failed to upcast animated CHyprColor");
                 updateColorVariable(*pTypedAV, POINTY, WARP);
             } break;
-            // case AVARTYPE_GRADIENT: {
-            //     auto pTypedAV = dynamic_cast<CAnimatedVariable<CGradientValueData>*>(PAV.get());
-            //     RASSERT(pTypedAV, "Failed to upcast animated CGradientValueData");
-            //     updateGradientVariable(*pTypedAV, POINTY, WARP);
-            // } break;
+            case AVARTYPE_GRADIENT: {
+                auto pTypedAV = dynamic_cast<CAnimatedVariable<CGradientValueData>*>(PAV.get());
+                RASSERT(pTypedAV, "Failed to upcast animated CGradientValueData");
+                updateGradientVariable(*pTypedAV, POINTY, WARP);
+            } break;
             default: continue;
         }
 

--- a/src/element/rectangle/Builder.cpp
+++ b/src/element/rectangle/Builder.cpp
@@ -15,6 +15,11 @@ SP<CRectangleBuilder> CRectangleBuilder::color(colorFn&& f) {
 }
 
 SP<CRectangleBuilder> CRectangleBuilder::borderColor(colorFn&& f) {
+    m_data->borderColor = [f = std::move(f)] { return CGradientValueData{f()}; };
+    return m_self.lock();
+}
+
+SP<CRectangleBuilder> CRectangleBuilder::borderGradient(gradientFn&& f) {
     m_data->borderColor = std::move(f);
     return m_self.lock();
 }

--- a/src/element/rectangle/Rectangle.cpp
+++ b/src/element/rectangle/Rectangle.cpp
@@ -45,7 +45,7 @@ void CRectangleElement::paint() {
     if (m_impl->data.borderThickness > 0) {
         g_renderer->renderBorder({
             .box      = impl->position,
-            .color    = m_impl->borderColor->value(),
+            .gradient = m_impl->borderColor->value(),
             .rounding = m_impl->data.rounding,
             .thick    = m_impl->data.borderThickness,
         });

--- a/src/element/rectangle/Rectangle.hpp
+++ b/src/element/rectangle/Rectangle.hpp
@@ -9,16 +9,16 @@ namespace Hyprtoolkit {
     struct SRectangleData {
         colorFn      color           = [] { return CHyprColor{1.F, 1.F, 1.F, 1.F}; };
         int          rounding        = 0;
-        colorFn      borderColor     = [] { return CHyprColor{1.F, 1.F, 1.F, 1.F}; };
+        gradientFn   borderColor     = [] { return CGradientValueData{CHyprColor{1.F, 1.F, 1.F, 1.F}}; };
         int          borderThickness = 0;
         CDynamicSize size{CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}};
     };
     struct SRectangleImpl {
-        SRectangleData         data;
+        SRectangleData                 data;
 
-        PHLANIMVAR<CHyprColor> color;
-        PHLANIMVAR<CHyprColor> borderColor;
+        PHLANIMVAR<CHyprColor>         color;
+        PHLANIMVAR<CGradientValueData> borderColor;
 
-        WP<CRectangleElement>  self;
+        WP<CRectangleElement>          self;
     };
 }

--- a/src/palette/Gradient.cpp
+++ b/src/palette/Gradient.cpp
@@ -1,0 +1,7 @@
+#include <hyprtoolkit/palette/Gradient.hpp>
+
+using namespace Hyprtoolkit;
+
+bool CGradientValueData::operator==(const CGradientValueData& rhs) const {
+    return m_fAngle == rhs.m_fAngle && m_vColors == rhs.m_vColors;
+}

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <hyprtoolkit/palette/Color.hpp>
+#include <hyprtoolkit/palette/Gradient.hpp>
 #include <hyprtoolkit/types/ImageTypes.hpp>
 #include <hyprutils/math/Box.hpp>
 #include <hyprgraphics/color/Color.hpp>
@@ -43,10 +44,10 @@ namespace Hyprtoolkit {
         };
 
         struct SBorderRenderData {
-            CBox       box;
-            CHyprColor color    = {1, 1, 1, 1};
-            int        rounding = 0;
-            int        thick    = 0;
+            CBox               box;
+            CGradientValueData gradient;
+            int                rounding = 0;
+            int                thick    = 0;
         };
 
         struct SPolygonRenderData {

--- a/src/renderer/gl/OpenGL.cpp
+++ b/src/renderer/gl/OpenGL.cpp
@@ -645,9 +645,9 @@ void COpenGLRenderer::renderBreadthfirst(SP<IElement> e) {
                 BOX.h = 1;
 
             renderBorder(SBorderRenderData{
-                .box   = BOX,
-                .color = DEBUG_COLOR,
-                .thick = 1,
+                .box      = BOX,
+                .gradient = CGradientValueData{DEBUG_COLOR},
+                .thick    = 1,
             });
 
             auto hsl = DEBUG_COLOR.asHSL();
@@ -949,12 +949,20 @@ void COpenGLRenderer::renderBorder(const SBorderRenderData& data) {
 
     glUniformMatrix3fv(m_borderShader.proj, 1, GL_TRUE, glMatrix.getMatrix().data());
 
-    const auto           OKLAB = data.color.asOkLab();
-    std::array<float, 4> grad  = {sc<float>(OKLAB.l), sc<float>(OKLAB.a), sc<float>(OKLAB.b), sc<float>(data.color.a)};
-
-    glUniform4fv(m_borderShader.gradient, grad.size() / 4, grad.data());
-    glUniform1i(m_borderShader.gradientLength, grad.size() / 4);
-    glUniform1f(m_borderShader.angle, (int)(0.F / (M_PI / 180.0)) % 360 * (M_PI / 180.0));
+    const int numStops = std::clamp(sc<int>(data.gradient.m_vColors.size()), 0, 10);
+    if (numStops > 0) {
+        std::array<float, 40> gradData{};
+        for (int i = 0; i < numStops; ++i) {
+            const auto OKL      = data.gradient.m_vColors[i].asOkLab();
+            gradData[i * 4 + 0] = sc<float>(OKL.l);
+            gradData[i * 4 + 1] = sc<float>(OKL.a);
+            gradData[i * 4 + 2] = sc<float>(OKL.b);
+            gradData[i * 4 + 3] = sc<float>(data.gradient.m_vColors[i].a);
+        }
+        glUniform4fv(m_borderShader.gradient, numStops, gradData.data());
+    }
+    glUniform1i(m_borderShader.gradientLength, numStops);
+    glUniform1f(m_borderShader.angle, data.gradient.m_fAngle);
     glUniform1f(m_borderShader.alpha, 1.F);
     glUniform1i(m_borderShader.gradient2Length, 0);
 


### PR DESCRIPTION
border shader already supported multi-stop gradients; this wires CGradientValueData (vector of CHyprColor stops plus an angle) into the animation manager with per-stop OkLab interpolation matching the existing color path, updates SBorderRenderData, and exposes borderGradient() on CRectangleBuilder. existing borderColor(colorFn) is unchanged.