### PR TITLE
element/checkbox: make checkmark color reactive

### DIFF
--- a/src/element/checkbox/Checkbox.cpp
+++ b/src/element/checkbox/Checkbox.cpp
@@ -19,18 +19,6 @@ SP<CCheckboxElement> CCheckboxElement::create(const SCheckboxData& data) {
     return p;
 }
 
-std::function<CHyprColor()> SCheckboxImpl::getFgColor() {
-    if (data.toggled)
-        return [] { return g_palette->m_colors.accent; };
-    else {
-        return [] {
-            auto c = g_palette->m_colors.accent;
-            c.a    = 0.F;
-            return c;
-        };
-    }
-}
-
 CCheckboxElement::CCheckboxElement(const SCheckboxData& data) : IElement(), m_impl(makeUnique<SCheckboxImpl>()) {
     m_impl->data = data;
 
@@ -45,10 +33,14 @@ CCheckboxElement::CCheckboxElement(const SCheckboxData& data) : IElement(), m_im
     m_impl->background->setPositionMode(HT_POSITION_ABSOLUTE);
     m_impl->background->setPositionFlag(HT_POSITION_FLAG_CENTER, true);
 
-    CHyprColor col = g_palette->m_colors.accent;
-    col.a          = m_impl->data.toggled ? 1.F : 0.F;
-    m_impl->foreground =
-        CCheckmarkElement::create(SCheckmarkData{.size = {CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}}, .color = [col] { return col; }});
+    m_impl->foreground = CCheckmarkElement::create(SCheckmarkData{
+        .size  = {CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}},
+        .color = [impl = m_impl.get()] {
+            auto c = g_palette->m_colors.accent;
+            c.a    = impl->data.toggled ? 1.F : 0.F;
+            return c;
+        },
+    });
 
     m_impl->foreground->setPositionMode(HT_POSITION_ABSOLUTE);
     m_impl->foreground->setPositionFlag(HT_POSITION_FLAG_CENTER, true);
@@ -90,9 +82,7 @@ CCheckboxElement::CCheckboxElement(const SCheckboxData& data) : IElement(), m_im
             if (m_impl->data.onToggled)
                 m_impl->data.onToggled(m_impl->self.lock(), m_impl->data.toggled);
 
-            CHyprColor col               = g_palette->m_colors.accent;
-            col.a                        = m_impl->data.toggled ? 1.F : 0.F;
-            *m_impl->foreground->m_color = col;
+            m_impl->foreground->recheckColor();
         }
     });
 
@@ -120,9 +110,7 @@ SP<CCheckboxBuilder> CCheckboxElement::rebuild() {
 void CCheckboxElement::replaceData(const SCheckboxData& data) {
     m_impl->data = data;
 
-    CHyprColor col               = g_palette->m_colors.accent;
-    col.a                        = m_impl->data.toggled ? 1.F : 0.F;
-    *m_impl->foreground->m_color = col;
+    m_impl->foreground->recheckColor();
 
     if (impl->window)
         impl->window->scheduleReposition(impl->self);

--- a/src/element/checkbox/Checkbox.hpp
+++ b/src/element/checkbox/Checkbox.hpp
@@ -24,6 +24,7 @@ namespace Hyprtoolkit {
         CCheckmarkElement(const SCheckmarkData& data);
 
         virtual void                                     paint();
+        virtual void                                     recheckColor();
         virtual void                                     reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize = {-1, -1});
         virtual Hyprutils::Math::Vector2D                size();
         virtual std::optional<Hyprutils::Math::Vector2D> preferredSize(const Hyprutils::Math::Vector2D& parent);
@@ -53,7 +54,5 @@ namespace Hyprtoolkit {
         bool                        labelChanged = true;
 
         bool                        primedForUp = false;
-
-        std::function<CHyprColor()> getFgColor();
     };
 }

--- a/src/element/checkbox/Checkmark.cpp
+++ b/src/element/checkbox/Checkmark.cpp
@@ -32,6 +32,10 @@ void CCheckmarkElement::paint() {
     });
 }
 
+void CCheckmarkElement::recheckColor() {
+    *m_color = m_data.color();
+}
+
 void CCheckmarkElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize) {
     IElement::reposition(box);
 


### PR DESCRIPTION
checkmark color was captured by value at construction, so the parent had to poke the child animated variable on every palette reload or toggle. CCheckmarkElement now overrides recheckColor() to re-run its stored color function, and the checkbox passes a reactive lambda. mouse handler and replaceData simplify to foreground->recheckColor(). same pattern as CRectangleElement.