### PR TITLE
element/slider: normalize value to percentage in replaceData

### DIFF
--- a/src/element/slider/Slider.cpp
+++ b/src/element/slider/Slider.cpp
@@ -150,7 +150,7 @@ void CSliderElement::replaceData(const SSliderData& data) {
     m_impl->data = data;
 
     if (VALUE_CHANGED) {
-        m_impl->valueChanged(data.current);
+        m_impl->valueChanged(m_impl->data.max != 0 ? m_impl->data.current / m_impl->data.max : 0.F);
 
         if (data.onChanged)
             data.onChanged(m_impl->self.lock(), m_impl->data.current);


### PR DESCRIPTION
replaceData passed data.current (raw) directly to valueChanged, which expects 0..1. with max=100 current=50 this stored 5000. pass current/max with a max==0 guard. onChanged still gets the raw value.