### PR TITLE
element/image: attach listener before enqueue to fix race

### DIFF
--- a/src/element/image/Image.cpp
+++ b/src/element/image/Image.cpp
@@ -106,9 +106,8 @@ void CImageElement::renderTex() {
 
     ASP<IAsyncResource> resourceGeneric(m_impl->resource);
 
-    g_asyncResourceGatherer->enqueue(resourceGeneric);
-
     if (!m_impl->data.sync) {
+        // attach listener before enqueueing to avoid missing the finished event
         m_impl->resource->m_events.finished.listenStatic([this, self = impl->self] {
             if (!self)
                 return;
@@ -120,7 +119,10 @@ void CImageElement::renderTex() {
                 m_impl->postImageLoad();
             });
         });
+
+        g_asyncResourceGatherer->enqueue(resourceGeneric);
     } else {
+        g_asyncResourceGatherer->enqueue(resourceGeneric);
         g_asyncResourceGatherer->await(resourceGeneric);
         m_impl->postImageLoad();
     }


### PR DESCRIPTION
finished listener was registered after enqueue(). under load the gatherer could complete and fire before the listener attached, leaving the image stuck with no texture. mirrors #48 in element/text.