### PR TITLE
core/backend: reset iconFactory and config in enterLoop

### DIFF
--- a/src/core/Backend.cpp
+++ b/src/core/Backend.cpp
@@ -543,6 +543,8 @@ void CBackend::enterLoop() {
     g_asyncResourceGatherer.reset();
     g_animationManager.reset();
 
+    g_iconFactory.reset();
+    g_config.reset();
     g_palette.reset();
     g_logger.reset();
 


### PR DESCRIPTION
terminate() resets g_iconFactory and g_config in its non-loop path; enterLoop() forgot them. on a normal loop exit the config inotify fd and the icon factory survive until static destructors run in unspecified order. add the two missing resets to match terminate().