### PR TITLE
element: add imperative setters for textbox, text, and button

### DIFF
--- a/include/hyprtoolkit/element/Button.hpp
+++ b/include/hyprtoolkit/element/Button.hpp
@@ -23,6 +23,7 @@ namespace Hyprtoolkit {
         Hyprutils::Memory::CSharedPointer<CButtonBuilder>        label(std::string&&);
         Hyprutils::Memory::CSharedPointer<CButtonBuilder>        noBorder(bool);
         Hyprutils::Memory::CSharedPointer<CButtonBuilder>        noBg(bool);
+        Hyprutils::Memory::CSharedPointer<CButtonBuilder>        enabled(bool);
         Hyprutils::Memory::CSharedPointer<CButtonBuilder>        alignText(eFontAlignment);
         Hyprutils::Memory::CSharedPointer<CButtonBuilder>        fontFamily(std::string&&);
         Hyprutils::Memory::CSharedPointer<CButtonBuilder>        fontSize(CFontSize&&);
@@ -48,6 +49,8 @@ namespace Hyprtoolkit {
 
         Hyprutils::Memory::CSharedPointer<CButtonBuilder> rebuild();
         virtual Hyprutils::Math::Vector2D                 size();
+        void                                              setLabel(std::string label);
+        void                                              setEnabled(bool enabled);
 
       private:
         CButtonElement(const SButtonData& data);

--- a/include/hyprtoolkit/element/Text.hpp
+++ b/include/hyprtoolkit/element/Text.hpp
@@ -54,6 +54,7 @@ namespace Hyprtoolkit {
 
         Hyprutils::Memory::CSharedPointer<CTextBuilder> rebuild();
         virtual Hyprutils::Math::Vector2D               size();
+        void                                            setText(std::string text);
 
         HT_HIDDEN : CTextElement(const STextData& data);
         static Hyprutils::Memory::CSharedPointer<CTextElement> create(const STextData& data);

--- a/include/hyprtoolkit/element/Textbox.hpp
+++ b/include/hyprtoolkit/element/Textbox.hpp
@@ -46,6 +46,8 @@ namespace Hyprtoolkit {
         std::string_view                                   currentText();
         size_t                                             cursorPos() const;
         std::tuple<ssize_t, ssize_t>                       selection() const;
+        void                                               setText(std::string text);
+        void                                               setPassword(bool password);
 
       private:
         static Hyprutils::Memory::CSharedPointer<CTextboxElement> create(const STextboxData& data);

--- a/src/element/button/Builder.cpp
+++ b/src/element/button/Builder.cpp
@@ -24,6 +24,11 @@ SP<CButtonBuilder> CButtonBuilder::noBg(bool x) {
     return m_self.lock();
 }
 
+SP<CButtonBuilder> CButtonBuilder::enabled(bool x) {
+    m_data->enabled = x;
+    return m_self.lock();
+}
+
 SP<CButtonBuilder> CButtonBuilder::fontFamily(std::string&& x) {
     m_data->fontFamily = std::move(x);
     return m_self.lock();

--- a/src/element/button/Button.cpp
+++ b/src/element/button/Button.cpp
@@ -38,7 +38,12 @@ CButtonElement::CButtonElement(const SButtonData& data) : IElement(), m_impl(mak
                         ->text(std::string{data.label})
                         ->fontSize(CFontSize{data.fontSize})
                         ->fontFamily(std::string{data.fontFamily})
-                        ->color([] { return g_palette->m_colors.text; })
+                        ->color([impl = m_impl.get()] {
+                            auto c = g_palette->m_colors.text;
+                            if (!impl->data.enabled)
+                                c.a *= 0.5F;
+                            return c;
+                        })
                         ->size({CDynamicSize::HT_SIZE_AUTO, CDynamicSize::HT_SIZE_AUTO, {1.F, 1.F}})
                         ->callback([this] {
                             m_impl->labelChanged = true;
@@ -59,6 +64,8 @@ CButtonElement::CButtonElement(const SButtonData& data) : IElement(), m_impl(mak
     m_impl->label->setMargin(2);
 
     impl->m_externalEvents.mouseEnter.listenStatic([this](const Vector2D& pos) {
+        if (!m_impl->data.enabled)
+            return;
         m_impl->background
             ->rebuild() //
             ->color([nb = m_impl->data.noBorder, nobg = m_impl->data.noBg] {
@@ -83,7 +90,7 @@ CButtonElement::CButtonElement(const SButtonData& data) : IElement(), m_impl(mak
     });
 
     impl->m_externalEvents.mouseButton.listenStatic([this](const Input::eMouseButton button, bool down) {
-        if (!down)
+        if (!down || !m_impl->data.enabled)
             return;
 
         if (button == Input::MOUSE_BUTTON_RIGHT) {
@@ -108,6 +115,25 @@ void CButtonElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutil
     g_positioner->positionChildren(impl->self.lock());
 }
 
+void CButtonElement::setLabel(std::string label) {
+    if (label == m_impl->data.label)
+        return;
+
+    m_impl->data.label = std::move(label);
+    m_impl->label->setText(m_impl->data.label);
+}
+
+void CButtonElement::setEnabled(bool enabled) {
+    if (enabled == m_impl->data.enabled)
+        return;
+
+    m_impl->data.enabled = enabled;
+    m_impl->label->recheckColor();
+
+    if (impl->window)
+        impl->window->scheduleReposition(impl->self);
+}
+
 SP<CButtonBuilder> CButtonElement::rebuild() {
     auto p       = SP<CButtonBuilder>(new CButtonBuilder());
     p->m_self    = p;
@@ -120,6 +146,7 @@ void CButtonElement::replaceData(const SButtonData& data) {
     m_impl->data = data;
 
     m_impl->label->rebuild()->text(std::string{data.label})->commence();
+    m_impl->label->recheckColor();
 
     m_impl->label->setPositionFlag(HT_POSITION_FLAG_ALL, false);
     m_impl->label->setPositionFlag(

--- a/src/element/button/Button.hpp
+++ b/src/element/button/Button.hpp
@@ -12,6 +12,7 @@ namespace Hyprtoolkit {
         std::string                                                            label      = "Click me";
         bool                                                                   noBorder   = false;
         bool                                                                   noBg       = false;
+        bool                                                                   enabled    = true;
         std::string                                                            fontFamily = g_palette ? g_palette->m_vars.fontFamily : "Sans Serif";
         CFontSize                                                              fontSize   = {CFontSize::HT_FONT_TEXT};
         eFontAlignment                                                         alignText  = HT_FONT_ALIGN_CENTER;

--- a/src/element/text/Text.cpp
+++ b/src/element/text/Text.cpp
@@ -48,6 +48,19 @@ CTextElement::CTextElement(const STextData& data) : IElement(), m_impl(makeUniqu
 
 CTextElement::~CTextElement() = default;
 
+void CTextElement::setText(std::string text) {
+    if (text == m_impl->data.text)
+        return;
+
+    m_impl->data.text = std::move(text);
+    m_impl->parseText();
+    m_impl->preferred = m_impl->getTextSizePreferred();
+    m_impl->scheduleTexRefresh();
+
+    if (impl->window)
+        impl->window->scheduleReposition(impl->self);
+}
+
 void CTextElement::replaceData(const STextData& data) {
     const bool TEXT_DIFFERENT = data.text != m_impl->data.text;
 

--- a/src/element/textbox/Textbox.cpp
+++ b/src/element/textbox/Textbox.cpp
@@ -357,6 +357,30 @@ size_t CTextboxElement::cursorPos() const {
     return m_impl->inputState.cursor;
 }
 
+void CTextboxElement::setText(std::string text) {
+    if (text == m_impl->data.text)
+        return;
+
+    m_impl->data.text   = std::move(text);
+    m_impl->inputState.cursor = std::min(m_impl->inputState.cursor, m_impl->data.text.length());
+    m_impl->clearSelect();
+    m_impl->updateLabel();
+
+    if (impl->window)
+        impl->window->scheduleReposition(impl->self);
+}
+
+void CTextboxElement::setPassword(bool password) {
+    if (password == m_impl->data.password)
+        return;
+
+    m_impl->data.password = password;
+    m_impl->updateLabel();
+
+    if (impl->window)
+        impl->window->scheduleReposition(impl->self);
+}
+
 std::tuple<ssize_t, ssize_t> CTextboxElement::selection() const {
     return {m_impl->inputState.selectBegin, m_impl->inputState.selectEnd};
 }


### PR DESCRIPTION
every state change required a builder rebuild and full replaceData. add direct setters that mutate, push the visual, and schedule reposition without going through the builder pipeline. CTextboxElement gains setText and setPassword, CTextElement gains setText, CButtonElement gains setLabel and setEnabled (plus an enabled flag on the data and builder). disabled buttons skip click and hover and dim their label.