### PR TITLE
element/textbox: refresh label on first window-attached reposition

### DIFF
--- a/src/element/textbox/Textbox.cpp
+++ b/src/element/textbox/Textbox.cpp
@@ -607,6 +607,11 @@ size_t STextboxImpl::moveCharForwards() const {
 void CTextboxElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize) {
     IElement::reposition(box);
 
+    if (!m_impl->firstAttachedPass && impl->window) {
+        m_impl->firstAttachedPass = true;
+        m_impl->updateLabel();
+    }
+
     g_positioner->positionChildren(impl->self.lock());
 }
 

--- a/src/element/textbox/Textbox.hpp
+++ b/src/element/textbox/Textbox.hpp
@@ -35,7 +35,8 @@ namespace Hyprtoolkit {
         SP<CTextElement>                   text;
         SP<CTextElement>                   placeholder;
 
-        bool                               active = false;
+        bool                               active            = false;
+        bool                               firstAttachedPass = false;
 
         struct {
             CHyprSignalListener key;


### PR DESCRIPTION
init() runs in create() before the textbox is attached to a window, so the initial updateLabel() schedules nothing and the post-tex callbacks bail. on the first reposition that has a window, run updateLabel() once to push the text and trigger a tex refresh at the correct scale.