### PR TITLE
Fix header inclusion for cross-platform compatibility

### DIFF
--- a/src/palette/ConfigManager.cpp
+++ b/src/palette/ConfigManager.cpp
@@ -8,7 +8,11 @@
 #include <glob.h>
 #include <filesystem>
 #include <cstring>
+#if defined(__linux__)
 #include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
 
 using namespace Hyprtoolkit;
 


### PR DESCRIPTION
This PR updates header inclusions to properly handle platform-specific limits.

Changes:

- Add conditional inclusion for `<linux/limits.h>` on Linux systems
- Use standard <limits.h> for other platforms