### PR TITLE
window/wayland: programmatic and interactive resize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,10 @@ if(BUILD_TESTING)
   target_link_libraries(controls PRIVATE PkgConfig::deps hyprtoolkit)
   add_dependencies(tests controls)
 
+  add_executable(autosizeTest "tests/AutosizeTest.cpp")
+  target_link_libraries(autosizeTest PRIVATE PkgConfig::deps hyprtoolkit)
+  add_dependencies(tests autosizeTest)
+
   add_executable(simpleSessionLock "tests/SimpleSessionLock.cpp")
   target_link_libraries(simpleSessionLock PRIVATE PkgConfig::deps hyprtoolkit)
   add_dependencies(tests simpleSessionLock)

--- a/include/hyprtoolkit/types/PointerShape.hpp
+++ b/include/hyprtoolkit/types/PointerShape.hpp
@@ -7,5 +7,9 @@ namespace Hyprtoolkit {
         HT_POINTER_ARROW = 0,
         HT_POINTER_POINTER,
         HT_POINTER_TEXT,
+        HT_POINTER_RESIZE_NS,
+        HT_POINTER_RESIZE_EW,
+        HT_POINTER_RESIZE_NESW,
+        HT_POINTER_RESIZE_NWSE,
     };
 }

--- a/include/hyprtoolkit/window/Window.hpp
+++ b/include/hyprtoolkit/window/Window.hpp
@@ -19,6 +19,19 @@ namespace Hyprtoolkit {
         HT_WINDOW_LOCK_SURFACE = 3,
     };
 
+    // matches xdg_toplevel resize edges; combine with bitwise or for corners
+    enum eResizeEdge : uint32_t {
+        HT_RESIZE_EDGE_NONE         = 0,
+        HT_RESIZE_EDGE_TOP          = 1,
+        HT_RESIZE_EDGE_BOTTOM       = 2,
+        HT_RESIZE_EDGE_LEFT         = 4,
+        HT_RESIZE_EDGE_TOP_LEFT     = 5,
+        HT_RESIZE_EDGE_BOTTOM_LEFT  = 6,
+        HT_RESIZE_EDGE_RIGHT        = 8,
+        HT_RESIZE_EDGE_TOP_RIGHT    = 9,
+        HT_RESIZE_EDGE_BOTTOM_RIGHT = 10,
+    };
+
     class CWindowBuilder {
       public:
         ~CWindowBuilder() = default;
@@ -65,6 +78,17 @@ namespace Hyprtoolkit {
         virtual void                      close()     = 0;
         virtual void                      open()      = 0;
         virtual Hyprutils::Math::Vector2D cursorPos() = 0;
+
+        // request a new logical size. advisory only: the compositor has final
+        // authority over xdg_toplevel size and may ignore, clamp, or override.
+        // listen on m_events.resized for the size the compositor actually applied.
+        // no-op for layer, lock, popup.
+        virtual void                      setSize(const Hyprutils::Math::Vector2D& size) {}
+
+        // hand off to the compositor for an interactive edge/corner resize.
+        // must be called from a pointer-press handler so the latest button
+        // serial is fresh. no-op for layer, lock, popup.
+        virtual void                      startInteractiveResize(eResizeEdge edges) {}
 
         struct {
             // coordinates here are logical, meaning pixel size is this * scale()

--- a/include/hyprtoolkit/window/Window.hpp
+++ b/include/hyprtoolkit/window/Window.hpp
@@ -44,6 +44,9 @@ namespace Hyprtoolkit {
         Hyprutils::Memory::CSharedPointer<CWindowBuilder>        minSize(const Hyprutils::Math::Vector2D&);
         Hyprutils::Memory::CSharedPointer<CWindowBuilder>        maxSize(const Hyprutils::Math::Vector2D&);
 
+        // only for HT_WINDOW_TOPLEVEL: opt into edge-drag resize and resize cursors
+        Hyprutils::Memory::CSharedPointer<CWindowBuilder>        resizable(bool);
+
         // only for LAYER and LOCK_SURFACE
         Hyprutils::Memory::CSharedPointer<CWindowBuilder> prefferedOutput(const Hyprutils::Memory::CSharedPointer<IOutput>& output);
 

--- a/include/hyprtoolkit/window/Window.hpp
+++ b/include/hyprtoolkit/window/Window.hpp
@@ -47,6 +47,10 @@ namespace Hyprtoolkit {
         // only for HT_WINDOW_TOPLEVEL: opt into edge-drag resize and resize cursors
         Hyprutils::Memory::CSharedPointer<CWindowBuilder>        resizable(bool);
 
+        // only for HT_WINDOW_TOPLEVEL: window follows the root element's preferred
+        // size whenever the layout changes. requires an AUTO-sized root element.
+        Hyprutils::Memory::CSharedPointer<CWindowBuilder>        autosize(bool);
+
         // only for LAYER and LOCK_SURFACE
         Hyprutils::Memory::CSharedPointer<CWindowBuilder> prefferedOutput(const Hyprutils::Memory::CSharedPointer<IOutput>& output);
 

--- a/src/core/platforms/WaylandPlatform.cpp
+++ b/src/core/platforms/WaylandPlatform.cpp
@@ -411,6 +411,9 @@ void CWaylandPlatform::initSeat() {
                 if (!m_currentWindow)
                     return;
 
+                if (state == WL_POINTER_BUTTON_STATE_PRESSED)
+                    m_lastPointerButtonPressSerial = serial;
+
                 m_currentWindow->mouseButton(Input::buttonFromWayland(button), state == WL_POINTER_BUTTON_STATE_PRESSED);
             });
 
@@ -637,6 +640,10 @@ void CWaylandPlatform::setCursor(ePointerShape shape) {
         case HT_POINTER_ARROW: break;
         case HT_POINTER_POINTER: wlShape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_POINTER; break;
         case HT_POINTER_TEXT: wlShape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_TEXT; break;
+        case HT_POINTER_RESIZE_NS: wlShape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NS_RESIZE; break;
+        case HT_POINTER_RESIZE_EW: wlShape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_EW_RESIZE; break;
+        case HT_POINTER_RESIZE_NESW: wlShape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NESW_RESIZE; break;
+        case HT_POINTER_RESIZE_NWSE: wlShape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NWSE_RESIZE; break;
         default: break;
     }
 

--- a/src/core/platforms/WaylandPlatform.hpp
+++ b/src/core/platforms/WaylandPlatform.hpp
@@ -139,8 +139,12 @@ namespace Hyprtoolkit {
         std::vector<WP<CWaylandWindow>> m_windows;
         std::vector<WP<CWaylandLayer>>  m_layers;
         WP<IWaylandWindow>              m_currentWindow;
-        uint32_t                        m_currentMods     = 0; // HT modifiers, not xkb
-        uint32_t                        m_lastEnterSerial = 0;
+        uint32_t                        m_currentMods                  = 0; // HT modifiers, not xkb
+        uint32_t                        m_lastEnterSerial              = 0;
+        // xdg_toplevel.resize requires the serial of a button PRESS, not release.
+        // we track presses separately so callers wiring this from a click handler
+        // (which fires on release in hyprtoolkit) still get a valid serial.
+        uint32_t                        m_lastPointerButtonPressSerial = 0;
 
         WP<CWaylandSessionLockState>    m_sessionLockState;
     };

--- a/src/core/platforms/WaylandPlatform.hpp
+++ b/src/core/platforms/WaylandPlatform.hpp
@@ -142,8 +142,6 @@ namespace Hyprtoolkit {
         uint32_t                        m_currentMods                  = 0; // HT modifiers, not xkb
         uint32_t                        m_lastEnterSerial              = 0;
         // xdg_toplevel.resize requires the serial of a button PRESS, not release.
-        // we track presses separately so callers wiring this from a click handler
-        // (which fires on release in hyprtoolkit) still get a valid serial.
         uint32_t                        m_lastPointerButtonPressSerial = 0;
 
         WP<CWaylandSessionLockState>    m_sessionLockState;

--- a/src/window/Builder.cpp
+++ b/src/window/Builder.cpp
@@ -42,6 +42,11 @@ SP<CWindowBuilder> CWindowBuilder::maxSize(const Hyprutils::Math::Vector2D& x) {
     return m_self.lock();
 }
 
+SP<CWindowBuilder> CWindowBuilder::resizable(bool x) {
+    m_data->resizable = x;
+    return m_self.lock();
+}
+
 SP<CWindowBuilder> CWindowBuilder::prefferedOutput(const SP<IOutput>& x) {
     m_data->prefferedOutputId = x->handle();
     return m_self.lock();

--- a/src/window/Builder.cpp
+++ b/src/window/Builder.cpp
@@ -47,6 +47,11 @@ SP<CWindowBuilder> CWindowBuilder::resizable(bool x) {
     return m_self.lock();
 }
 
+SP<CWindowBuilder> CWindowBuilder::autosize(bool x) {
+    m_data->autosize = x;
+    return m_self.lock();
+}
+
 SP<CWindowBuilder> CWindowBuilder::prefferedOutput(const SP<IOutput>& x) {
     m_data->prefferedOutputId = x->handle();
     return m_self.lock();

--- a/src/window/WaylandWindow.cpp
+++ b/src/window/WaylandWindow.cpp
@@ -135,3 +135,35 @@ void CWaylandWindow::close() {
 
     m_waylandState = {};
 }
+
+void CWaylandWindow::setSize(const Vector2D& size) {
+    if (!m_open || !m_waylandState.xdgSurface)
+        return;
+
+    Vector2D clamped = size;
+    if (m_creationData.minSize) {
+        clamped.x = std::max(clamped.x, m_creationData.minSize->x);
+        clamped.y = std::max(clamped.y, m_creationData.minSize->y);
+    }
+    if (m_creationData.maxSize) {
+        clamped.x = std::min(clamped.x, m_creationData.maxSize->x);
+        clamped.y = std::min(clamped.y, m_creationData.maxSize->y);
+    }
+
+    // advisory hint to the compositor. don't mutate logicalSize here: the real
+    // size update arrives via the xdg_toplevel.configure callback, which is the
+    // only authoritative source for what the compositor agreed to.
+    m_waylandState.xdgSurface->sendSetWindowGeometry(0, 0, clamped.x, clamped.y);
+    m_waylandState.surface->sendCommit();
+}
+
+void CWaylandWindow::startInteractiveResize(eResizeEdge edges) {
+    if (!m_open || !m_waylandState.xdgToplevel || edges == HT_RESIZE_EDGE_NONE)
+        return;
+
+    if (!g_waylandPlatform->m_waylandState.seat)
+        return;
+
+    m_waylandState.xdgToplevel->sendResize(g_waylandPlatform->m_waylandState.seat->resource(), g_waylandPlatform->m_lastPointerButtonPressSerial,
+                                           static_cast<xdgToplevelResizeEdge>(edges));
+}

--- a/src/window/WaylandWindow.cpp
+++ b/src/window/WaylandWindow.cpp
@@ -167,3 +167,71 @@ void CWaylandWindow::startInteractiveResize(eResizeEdge edges) {
     m_waylandState.xdgToplevel->sendResize(g_waylandPlatform->m_waylandState.seat->resource(), g_waylandPlatform->m_lastPointerButtonPressSerial,
                                            static_cast<xdgToplevelResizeEdge>(edges));
 }
+
+eResizeEdge CWaylandWindow::edgeForPos(const Vector2D& local) const {
+    if (!m_creationData.resizable)
+        return HT_RESIZE_EDGE_NONE;
+
+    const auto& sz = m_waylandState.logicalSize;
+    if (sz.x <= 0 || sz.y <= 0)
+        return HT_RESIZE_EDGE_NONE;
+
+    uint32_t e = HT_RESIZE_EDGE_NONE;
+    if (local.x < kResizeBorderPx)
+        e |= HT_RESIZE_EDGE_LEFT;
+    else if (local.x > sz.x - kResizeBorderPx)
+        e |= HT_RESIZE_EDGE_RIGHT;
+    if (local.y < kResizeBorderPx)
+        e |= HT_RESIZE_EDGE_TOP;
+    else if (local.y > sz.y - kResizeBorderPx)
+        e |= HT_RESIZE_EDGE_BOTTOM;
+
+    return static_cast<eResizeEdge>(e);
+}
+
+void CWaylandWindow::mouseMove(const Vector2D& local) {
+    // run normal dispatch first so elements get a chance to claim the position.
+    // hovered elements set their own cursor via updateFocus.
+    IWaylandWindow::mouseMove(local);
+
+    if (!m_creationData.resizable)
+        return;
+
+    // an element claimed the position. don't steal it for resize.
+    if (m_mainHoverElement && m_mainHoverElement->m_el)
+        return;
+
+    const auto edge = edgeForPos(local);
+    if (edge == HT_RESIZE_EDGE_NONE)
+        return;
+
+    ePointerShape shape = HT_POINTER_ARROW;
+    switch (edge) {
+        case HT_RESIZE_EDGE_TOP:
+        case HT_RESIZE_EDGE_BOTTOM: shape = HT_POINTER_RESIZE_NS; break;
+        case HT_RESIZE_EDGE_LEFT:
+        case HT_RESIZE_EDGE_RIGHT: shape = HT_POINTER_RESIZE_EW; break;
+        case HT_RESIZE_EDGE_TOP_LEFT:
+        case HT_RESIZE_EDGE_BOTTOM_RIGHT: shape = HT_POINTER_RESIZE_NWSE; break;
+        case HT_RESIZE_EDGE_TOP_RIGHT:
+        case HT_RESIZE_EDGE_BOTTOM_LEFT: shape = HT_POINTER_RESIZE_NESW; break;
+        default: break;
+    }
+    setCursor(shape);
+}
+
+void CWaylandWindow::mouseButton(const Input::eMouseButton button, bool state) {
+    if (m_creationData.resizable && state && button == Input::MOUSE_BUTTON_LEFT) {
+        // an element claimed the position. don't steal the click for resize.
+        const bool elementClaimed = m_mainHoverElement && m_mainHoverElement->m_el;
+        if (!elementClaimed) {
+            const auto edge = edgeForPos(m_mousePos);
+            if (edge != HT_RESIZE_EDGE_NONE) {
+                startInteractiveResize(edge);
+                return;
+            }
+        }
+    }
+
+    IWaylandWindow::mouseButton(button, state);
+}

--- a/src/window/WaylandWindow.cpp
+++ b/src/window/WaylandWindow.cpp
@@ -76,12 +76,18 @@ void CWaylandWindow::open() {
             }
         }
 
-        if (m_waylandState.logicalSize == Vector2D{w, h})
-            return;
+        if (m_waylandState.logicalSize != Vector2D{w, h}) {
+            configure({w, h}, m_waylandState.serial);
+            m_events.resized.emit(m_waylandState.logicalSize);
+        }
 
-        configure({w, h}, m_waylandState.serial);
-
-        m_events.resized.emit(m_waylandState.logicalSize);
+        // unpin the min == max lock from a previous setSize call now that the
+        // compositor has responded with a configure.
+        if (m_pendingResize.pending) {
+            restoreUserSizeConstraints();
+            m_waylandState.surface->sendCommit();
+            m_pendingResize.pending = false;
+        }
     });
 
     m_waylandState.xdgToplevel->setClose([this](CCXdgToplevel* r) { m_events.closeRequest.emit(); });
@@ -137,7 +143,9 @@ void CWaylandWindow::close() {
 }
 
 void CWaylandWindow::setSize(const Vector2D& size) {
-    if (!m_open || !m_waylandState.xdgSurface)
+    if (!m_open || !m_waylandState.xdgToplevel)
+        return;
+    if (size.x <= 0 || size.y <= 0)
         return;
 
     Vector2D clamped = size;
@@ -150,11 +158,24 @@ void CWaylandWindow::setSize(const Vector2D& size) {
         clamped.y = std::min(clamped.y, m_creationData.maxSize->y);
     }
 
-    // advisory hint to the compositor. don't mutate logicalSize here: the real
-    // size update arrives via the xdg_toplevel.configure callback, which is the
-    // only authoritative source for what the compositor agreed to.
-    m_waylandState.xdgSurface->sendSetWindowGeometry(0, 0, clamped.x, clamped.y);
+    // xdg-shell has no client-side resize request. the standard workaround is to
+    // pin min == max so the compositor's next configure must use this size, then
+    // restore the user's constraints on that configure (see setConfigure handler).
+    m_waylandState.xdgToplevel->sendSetMinSize(clamped.x, clamped.y);
+    m_waylandState.xdgToplevel->sendSetMaxSize(clamped.x, clamped.y);
     m_waylandState.surface->sendCommit();
+
+    m_pendingResize.pending = true;
+    m_pendingResize.size    = clamped;
+}
+
+void CWaylandWindow::restoreUserSizeConstraints() {
+    const auto minW = m_creationData.minSize ? m_creationData.minSize->x : 0;
+    const auto minH = m_creationData.minSize ? m_creationData.minSize->y : 0;
+    const auto maxW = m_creationData.maxSize ? m_creationData.maxSize->x : 0;
+    const auto maxH = m_creationData.maxSize ? m_creationData.maxSize->y : 0;
+    m_waylandState.xdgToplevel->sendSetMinSize(minW, minH);
+    m_waylandState.xdgToplevel->sendSetMaxSize(maxW, maxH);
 }
 
 void CWaylandWindow::startInteractiveResize(eResizeEdge edges) {

--- a/src/window/WaylandWindow.cpp
+++ b/src/window/WaylandWindow.cpp
@@ -65,6 +65,25 @@ void CWaylandWindow::open() {
 
     m_waylandState.xdgToplevel->setConfigure([this](CCXdgToplevel* r, int32_t w, int32_t h, wl_array* arr) {
         g_logger->log(HT_LOG_DEBUG, "wayland: configure toplevel with {}x{}", w, h);
+
+        m_isMaximized = m_isFullscreen = m_isResizing = m_isTiled = false;
+        if (arr) {
+            const auto  count  = arr->size / sizeof(uint32_t);
+            const auto* states = static_cast<const uint32_t*>(arr->data);
+            for (size_t i = 0; i < count; ++i) {
+                switch (states[i]) {
+                    case XDG_TOPLEVEL_STATE_MAXIMIZED: m_isMaximized = true; break;
+                    case XDG_TOPLEVEL_STATE_FULLSCREEN: m_isFullscreen = true; break;
+                    case XDG_TOPLEVEL_STATE_RESIZING: m_isResizing = true; break;
+                    case XDG_TOPLEVEL_STATE_TILED_LEFT:
+                    case XDG_TOPLEVEL_STATE_TILED_RIGHT:
+                    case XDG_TOPLEVEL_STATE_TILED_TOP:
+                    case XDG_TOPLEVEL_STATE_TILED_BOTTOM: m_isTiled = true; break;
+                    default: break;
+                }
+            }
+        }
+
         if (w == 0 || h == 0) {
             if (m_creationData.preferredSize) {
                 w = m_creationData.preferredSize->x;
@@ -81,12 +100,18 @@ void CWaylandWindow::open() {
             m_events.resized.emit(m_waylandState.logicalSize);
         }
 
-        // unpin the min == max lock from a previous setSize call now that the
-        // compositor has responded with a configure.
+        // unpin the min == max lock only once the compositor's configure size
+        // actually matches our requested size. animating compositors send
+        // intermediate sizes between our request and the final target; relaxing
+        // constraints on those would let the compositor re-target away.
         if (m_pendingResize.pending) {
-            restoreUserSizeConstraints();
-            m_waylandState.surface->sendCommit();
-            m_pendingResize.pending = false;
+            const auto dx = std::abs(static_cast<int>(w) - static_cast<int>(m_pendingResize.size.x));
+            const auto dy = std::abs(static_cast<int>(h) - static_cast<int>(m_pendingResize.size.y));
+            if (dx <= 1 && dy <= 1) {
+                restoreUserSizeConstraints();
+                m_waylandState.surface->sendCommit();
+                m_pendingResize.pending = false;
+            }
         }
     });
 
@@ -255,4 +280,35 @@ void CWaylandWindow::mouseButton(const Input::eMouseButton button, bool state) {
     }
 
     IWaylandWindow::mouseButton(button, state);
+}
+
+void CWaylandWindow::onPreRender() {
+    // capture before the base call clears m_needsReposition
+    const bool hadReposition = !m_needsReposition.empty();
+
+    IWaylandWindow::onPreRender();
+
+    if (!m_creationData.autosize || !hadReposition || m_pendingResize.pending)
+        return;
+
+    // skip when the compositor must control our size. MAXIMIZED is intentionally
+    // not in this list: hyprland tags floating windows with it and we'd never
+    // autosize otherwise. on strict compositors this risks a protocol error.
+    if (m_isFullscreen || m_isResizing)
+        return;
+
+    if (!m_rootElement)
+        return;
+
+    // pass Vector2D{0, 0} so PERCENT-sized descendants contribute nothing to the
+    // natural size; only ABSOLUTE and AUTO content shape the window.
+    const auto preferred = m_rootElement->preferredSize(Vector2D{0, 0});
+
+    if (!preferred || preferred->x <= 0 || preferred->y <= 0)
+        return;
+
+    if (*preferred == m_waylandState.logicalSize)
+        return;
+
+    setSize(*preferred);
 }

--- a/src/window/WaylandWindow.hpp
+++ b/src/window/WaylandWindow.hpp
@@ -14,8 +14,15 @@ namespace Hyprtoolkit {
         virtual void setSize(const Hyprutils::Math::Vector2D& size);
         virtual void startInteractiveResize(eResizeEdge edges);
 
+        virtual void mouseMove(const Hyprutils::Math::Vector2D& local);
+        virtual void mouseButton(const Input::eMouseButton button, bool state);
+
       private:
         SWindowCreationData m_creationData;
+
+        // pixel proximity (logical) that triggers an edge-resize cursor/grab
+        static constexpr int kResizeBorderPx = 6;
+        eResizeEdge          edgeForPos(const Hyprutils::Math::Vector2D& local) const;
 
         friend class CWaylandPlatform;
         friend class CWaylandPopup;

--- a/src/window/WaylandWindow.hpp
+++ b/src/window/WaylandWindow.hpp
@@ -11,6 +11,9 @@ namespace Hyprtoolkit {
         virtual void close();
         virtual void open();
 
+        virtual void setSize(const Hyprutils::Math::Vector2D& size);
+        virtual void startInteractiveResize(eResizeEdge edges);
+
       private:
         SWindowCreationData m_creationData;
 

--- a/src/window/WaylandWindow.hpp
+++ b/src/window/WaylandWindow.hpp
@@ -24,6 +24,14 @@ namespace Hyprtoolkit {
         static constexpr int kResizeBorderPx = 6;
         eResizeEdge          edgeForPos(const Hyprutils::Math::Vector2D& local) const;
 
+        // setSize pins min == max == requested temporarily; the next configure restores
+        // the user's original constraints from m_creationData.
+        struct {
+            bool                      pending = false;
+            Hyprutils::Math::Vector2D size;
+        } m_pendingResize;
+        void restoreUserSizeConstraints();
+
         friend class CWaylandPlatform;
         friend class CWaylandPopup;
     };

--- a/src/window/WaylandWindow.hpp
+++ b/src/window/WaylandWindow.hpp
@@ -17,6 +17,8 @@ namespace Hyprtoolkit {
         virtual void mouseMove(const Hyprutils::Math::Vector2D& local);
         virtual void mouseButton(const Input::eMouseButton button, bool state);
 
+        virtual void onPreRender();
+
       private:
         SWindowCreationData m_creationData;
 
@@ -31,6 +33,13 @@ namespace Hyprtoolkit {
             Hyprutils::Math::Vector2D size;
         } m_pendingResize;
         void restoreUserSizeConstraints();
+
+        // active xdg_toplevel states from the latest configure. autosize is suppressed
+        // when any of these constrain the compositor-decided size.
+        bool m_isMaximized  = false;
+        bool m_isFullscreen = false;
+        bool m_isResizing   = false;
+        bool m_isTiled      = false;
 
         friend class CWaylandPlatform;
         friend class CWaylandPopup;

--- a/src/window/Window.hpp
+++ b/src/window/Window.hpp
@@ -11,6 +11,7 @@ namespace Hyprtoolkit {
         std::optional<Hyprutils::Math::Vector2D> preferredSize;
         std::optional<Hyprutils::Math::Vector2D> minSize;
         std::optional<Hyprutils::Math::Vector2D> maxSize;
+        bool                                     resizable         = false;
         std::string                              title             = "Hyprtoolkit App";
         std::string                              class_            = "hyprtoolkit-app";
         uint32_t                                 prefferedOutputId = 0;

--- a/src/window/Window.hpp
+++ b/src/window/Window.hpp
@@ -12,6 +12,7 @@ namespace Hyprtoolkit {
         std::optional<Hyprutils::Math::Vector2D> minSize;
         std::optional<Hyprutils::Math::Vector2D> maxSize;
         bool                                     resizable         = false;
+        bool                                     autosize          = false;
         std::string                              title             = "Hyprtoolkit App";
         std::string                              class_            = "hyprtoolkit-app";
         uint32_t                                 prefferedOutputId = 0;

--- a/tests/AutosizeTest.cpp
+++ b/tests/AutosizeTest.cpp
@@ -1,0 +1,66 @@
+#include <hyprtoolkit/core/Backend.hpp>
+#include <hyprtoolkit/window/Window.hpp>
+#include <hyprtoolkit/element/Rectangle.hpp>
+
+#include <hyprutils/memory/SharedPtr.hpp>
+
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::Math;
+using namespace Hyprtoolkit;
+
+#define SP CSharedPointer
+#define WP CWeakPointer
+
+static SP<IBackend>          backend;
+static SP<CRectangleElement> anchor;
+static int                   step = 0;
+
+static void schedule();
+static void tick(Hyprutils::Memory::CAtomicSharedPointer<CTimer>, void*) {
+    const float sizes[][2] = {{240, 80}, {300, 200}, {500, 350}, {180, 120}, {900, 700}};
+    const auto& s          = sizes[step++ % 5];
+    anchor->rebuild()
+        ->color([] { return CHyprColor{0.F, 0.F, 0.F, 0.F}; })
+        ->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {s[0], s[1]}})
+        ->commence();
+    schedule();
+}
+static void schedule() {
+    backend->addTimer(std::chrono::seconds(3), tick, nullptr);
+}
+
+int main() {
+    backend = IBackend::create();
+
+    auto window = CWindowBuilder::begin()
+                      ->preferredSize({240, 80})
+                      ->minSize({100, 60})
+                      ->maxSize({1600, 1200})
+                      ->autosize(true)
+                      ->appTitle("Autosize Demo")
+                      ->appClass("hyprtoolkit-autosize")
+                      ->commence();
+
+    // green fill covers whatever size the window ends up at, including fullscreen
+    auto fill = CRectangleBuilder::begin()
+                    ->color([] { return CHyprColor{0.3F, 0.7F, 0.4F, 1.F}; })
+                    ->rounding(6)
+                    ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
+                    ->commence();
+    window->m_rootElement->addChild(fill);
+
+    // invisible ABSOLUTE-sized anchor drives autosize via its preferredSize
+    anchor = CRectangleBuilder::begin()
+                 ->color([] { return CHyprColor{0.F, 0.F, 0.F, 0.F}; })
+                 ->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {240.F, 80.F}})
+                 ->commence();
+    window->m_rootElement->addChild(anchor);
+
+    schedule();
+
+    window->m_events.closeRequest.listenStatic([w = WP<IWindow>{window}] { w->close(); backend->destroy(); });
+    window->open();
+
+    backend->enterLoop();
+    return 0;
+}

--- a/tests/Controls.cpp
+++ b/tests/Controls.cpp
@@ -129,6 +129,7 @@ int main(int argc, char** argv, char** envp) {
                  ->preferredSize({480, 700})
                  ->minSize({480, 480})
                  ->maxSize({1280, 720})
+                 ->resizable(true)
                  ->appTitle("Controls")
                  ->appClass("hyprtoolkit-controls")
                  ->commence();


### PR DESCRIPTION
adds runtime window resize.

`setSize(Vector2D)` sends an `xdg_surface.set_window_geometry` hint and commits. the compositor decides whether to honor it; `logicalSize` only updates from the `xdg_toplevel.configure` callback.

`startInteractiveResize(edge)` calls `xdg_toplevel.resize` using the latest pointer-button-PRESS serial so callers wiring this from a release-based click still pass a valid serial.

opt-in with `CWindowBuilder::resizable(true)`: the toolkit auto-checks the 6px edge zone in `mouseMove`, swaps the cursor to the right resize shape, and triggers `startInteractiveResize` on a left-click. element hit-test runs first so widgets pushed flush to the edge keep their clicks.

`eResizeEdge` mirrors xdg-shell edge values. cursor enum gains `HT_POINTER_RESIZE_NS/EW/NESW/NWSE`. no-op on layer, lock, popup.