### PR TITLE
system/icons: skip already-parsed themes to break inherit cycles

### DIFF
--- a/src/system/Icons.cpp
+++ b/src/system/Icons.cpp
@@ -168,6 +168,11 @@ static std::optional<std::vector<std::string>> getIconThemeDirs() {
 }
 
 void CSystemIconFactory::parseTheme(const std::string& themeDir) {
+    if (!m_parsedThemes.insert(themeDir).second) {
+        g_logger->log(HT_LOG_TRACE, "CSystemIconFactory: theme {} already parsed, skipping", themeDir);
+        return;
+    }
+
     const auto THEME_DATA = readFileAsString(themeDir + "/index.theme");
 
     if (!THEME_DATA)

--- a/src/system/Icons.hpp
+++ b/src/system/Icons.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <filesystem>
 #include <vector>
+#include <unordered_set>
 
 namespace Hyprtoolkit {
     class CSystemIconDescription : public ISystemIconDescription {
@@ -52,7 +53,10 @@ namespace Hyprtoolkit {
         void                     parseThemes(const std::vector<std::string>& themeDirs);
         void                     parseTheme(const std::string& themeDir);
 
-        std::vector<std::string> m_lookupPaths;
+        std::vector<std::string>        m_lookupPaths;
+
+        // theme dirs already walked, to break cyclic Inherits= chains
+        std::unordered_set<std::string> m_parsedThemes;
 
         absl::flat_hash_map<std::string, SIconCacheResult> m_pathCache;
 


### PR DESCRIPTION
Closes #82.

`parseTheme` recursed into every `Inherits=` target with no cycle guard, so a self-inheriting or mutually-inheriting `index.theme` anywhere on the icon search path stack-overflowed every hyprtoolkit binary at startup.

Keeps a set of parsed theme dirs, keyed on the resolved dir path, and skips re-entry at the top of `parseTheme`. Keying on the dir path also drops the duplicate `Directories=` appends when several themes inherit a common ancestor.

Tested: reproduced the SIGSEGV with an A/B `Inherits=` cycle, then confirmed the fix against self-inherit, 2 and 3 cycles, a 31-deep loop, fan-out with mixed cycles and missing themes, and malformed/binary `index.theme` files. Legit non-cyclic chains still parse every theme.
