### PR TITLE
element/textbox: add eye icon for password visibility toggle

### DIFF
--- a/include/hyprtoolkit/element/Textbox.hpp
+++ b/include/hyprtoolkit/element/Textbox.hpp
@@ -22,6 +22,7 @@ namespace Hyprtoolkit {
         Hyprutils::Memory::CSharedPointer<CTextboxBuilder>        onTextEdited(std::function<void(Hyprutils::Memory::CSharedPointer<CTextboxElement>, const std::string&)>&&);
         Hyprutils::Memory::CSharedPointer<CTextboxBuilder>        multiline(bool);
         Hyprutils::Memory::CSharedPointer<CTextboxBuilder>        password(bool);
+        Hyprutils::Memory::CSharedPointer<CTextboxBuilder>        eyeIcon(bool);
         Hyprutils::Memory::CSharedPointer<CTextboxBuilder>        size(CDynamicSize&&);
 
         Hyprutils::Memory::CSharedPointer<CTextboxElement>        commence();

--- a/src/element/textbox/Builder.cpp
+++ b/src/element/textbox/Builder.cpp
@@ -39,6 +39,11 @@ SP<CTextboxBuilder> CTextboxBuilder::password(bool x) {
     return m_self.lock();
 }
 
+SP<CTextboxBuilder> CTextboxBuilder::eyeIcon(bool x) {
+    m_data->eyeIcon = x;
+    return m_self.lock();
+}
+
 SP<CTextboxElement> CTextboxBuilder::commence() {
     if (m_element) {
         m_element->replaceData(*m_data);

--- a/src/element/textbox/Textbox.cpp
+++ b/src/element/textbox/Textbox.cpp
@@ -398,7 +398,7 @@ void CTextboxElement::init() {
                             ->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_PERCENT, {STextboxImpl::EYE_W, 1.F}})
                             ->commence();
         m_impl->eyeText = CTextBuilder::begin()
-                              ->text(std::string{"\xef\x81\xae"})
+                              ->text(std::string{""})
                               ->color([] { return g_palette->m_colors.text.darken(0.4F); })
                               ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
                               ->commence();
@@ -453,7 +453,7 @@ void CTextboxElement::setPassword(bool password) {
 void STextboxImpl::updateEyeSymbol() {
     if (!eyeText)
         return;
-    eyeText->rebuild()->text(std::string{data.password ? "\xef\x81\xae" : "\xef\x81\xb0"})->commence();
+    eyeText->rebuild()->text(std::string{data.password ? "" : ""})->commence();
 }
 
 std::tuple<ssize_t, ssize_t> CTextboxElement::selection() const {

--- a/src/element/textbox/Textbox.cpp
+++ b/src/element/textbox/Textbox.cpp
@@ -77,8 +77,15 @@ void CTextboxElement::init() {
     m_impl->listeners.mouseMove = impl->m_externalEvents.mouseMove.listen([this](Vector2D pos) { m_impl->lastCursorPos = pos; });
 
     m_impl->listeners.mouseButton = impl->m_externalEvents.mouseButton.listen([this](Input::eMouseButton button, bool down) {
-        if (down)
+        if (!down)
+            return;
+        if (m_impl->eyeBg && m_impl->lastCursorPos.x >= impl->position.w - STextboxImpl::EYE_W) {
+            m_impl->data.password = !m_impl->data.password;
+            m_impl->updateLabel();
+            m_impl->updateEyeSymbol();
+        } else {
             m_impl->focusCursorAtClickedChar();
+        }
     });
 
     m_impl->listeners.enter = impl->m_externalEvents.keyboardEnter.listen([this] {
@@ -385,6 +392,26 @@ void CTextboxElement::init() {
     m_impl->cursorCont->addChild(m_impl->cursor);
     m_impl->bg->impl->clipChildren = true;
 
+    if (m_impl->data.eyeIcon) {
+        m_impl->eyeBg = CRectangleBuilder::begin()
+                            ->color([] { return CHyprColor{0.F, 0.F, 0.F, 0.F}; })
+                            ->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_PERCENT, {STextboxImpl::EYE_W, 1.F}})
+                            ->commence();
+        m_impl->eyeText = CTextBuilder::begin()
+                              ->text(std::string{"\xef\x81\xae"})
+                              ->color([] { return g_palette->m_colors.text.darken(0.4F); })
+                              ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
+                              ->commence();
+        m_impl->eyeText->setPositionMode(HT_POSITION_ABSOLUTE);
+        m_impl->eyeText->setPositionFlag(HT_POSITION_FLAG_HCENTER, true);
+        m_impl->eyeText->setPositionFlag(HT_POSITION_FLAG_VCENTER, true);
+        m_impl->eyeBg->addChild(m_impl->eyeText);
+        m_impl->eyeBg->setPositionMode(HT_POSITION_ABSOLUTE);
+        m_impl->eyeBg->setPositionFlag(HT_POSITION_FLAG_RIGHT, true);
+        m_impl->eyeBg->setPositionFlag(HT_POSITION_FLAG_VCENTER, true);
+        m_impl->bg->addChild(m_impl->eyeBg);
+    }
+
     m_impl->updateLabel();
 
     impl->grouped = true;
@@ -417,9 +444,16 @@ void CTextboxElement::setPassword(bool password) {
 
     m_impl->data.password = password;
     m_impl->updateLabel();
+    m_impl->updateEyeSymbol();
 
     if (impl->window)
         impl->window->scheduleReposition(impl->self);
+}
+
+void STextboxImpl::updateEyeSymbol() {
+    if (!eyeText)
+        return;
+    eyeText->rebuild()->text(std::string{data.password ? "\xef\x81\xae" : "\xef\x81\xb0"})->commence();
 }
 
 std::tuple<ssize_t, ssize_t> CTextboxElement::selection() const {
@@ -710,6 +744,7 @@ void CTextboxElement::replaceData(const STextboxData& data) {
         m_impl->placeholder->rebuild()->text(std::string{data.placeholder})->commence();
 
     m_impl->updateLabel();
+    m_impl->updateEyeSymbol();
 
     if (impl->window)
         impl->window->scheduleReposition(impl->self);

--- a/src/element/textbox/Textbox.hpp
+++ b/src/element/textbox/Textbox.hpp
@@ -19,6 +19,7 @@ namespace Hyprtoolkit {
         std::function<void(Hyprutils::Memory::CSharedPointer<CTextboxElement>, const std::string&)> onTextEdited;
         bool                                                                                        multiline = true;
         bool                                                                                        password  = false;
+        bool                                                                                        eyeIcon   = false;
         CDynamicSize                                                                                size{CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}};
     };
     struct STextboxImpl {
@@ -34,6 +35,10 @@ namespace Hyprtoolkit {
         std::vector<SP<CRectangleElement>> selectBgs;
         SP<CTextElement>                   text;
         SP<CTextElement>                   placeholder;
+        SP<CRectangleElement>              eyeBg;
+        SP<CTextElement>                   eyeText;
+
+        static constexpr float             EYE_W = 28.F;
 
         bool                               active            = false;
         bool                               firstAttachedPass = false;
@@ -54,6 +59,7 @@ namespace Hyprtoolkit {
 
         void                      clearSelect();
         void                      updateSelect();
+        void                      updateEyeSymbol();
         bool                      hasSelect() const;
         void                      removeSelectedText();
         void                      focusCursorAtClickedChar();


### PR DESCRIPTION
adds an `eyeIcon(true)` opt in on CTextboxBuilder. when enabled with `password(true)` it renders a small eye toggle on the right of the textbox that flips the masking state on click via `setPassword`.

you mentioned wanting this in hyprwm/hyprpolkitagent#50: "we could add to the toolkit an option to show an eye icon on the right for toggling visibility instead of the 'show' button." the polkit agent already calls `eyeIcon(true)` on its password field but I had only pushed the branch to my fork and never opened the PR here. submitting it properly now so the agent can drop the fork dependency.