### PR TITLE
element/textbox: hover cursor and highlight on the eye icon

### DIFF
--- a/include/hyprtoolkit/element/Textbox.hpp
+++ b/include/hyprtoolkit/element/Textbox.hpp
@@ -64,6 +64,7 @@ namespace Hyprtoolkit {
         virtual std::optional<Hyprutils::Math::Vector2D> maximumSize(const Hyprutils::Math::Vector2D& parent);
         virtual bool                                     acceptsMouseInput();
         virtual ePointerShape                            pointerShape();
+        virtual std::function<ePointerShape()>           pointerShapeFn();
         virtual bool                                     acceptsKeyboardInput();
         virtual void                                     imCommitNewText(const std::string&);
         virtual void                                     imApplyText();

--- a/src/element/textbox/Textbox.cpp
+++ b/src/element/textbox/Textbox.cpp
@@ -74,7 +74,29 @@ void CTextboxElement::init() {
     if (!m_impl->data.multiline)
         m_impl->text->setPositionFlag(HT_POSITION_FLAG_VCENTER, true);
 
-    m_impl->listeners.mouseMove = impl->m_externalEvents.mouseMove.listen([this](Vector2D pos) { m_impl->lastCursorPos = pos; });
+    m_impl->listeners.mouseMove = impl->m_externalEvents.mouseMove.listen([this](Vector2D pos) {
+        m_impl->lastCursorPos = pos;
+        if (!m_impl->eyeBg)
+            return;
+        const bool IN_EYE = pos.x >= impl->position.w - STextboxImpl::EYE_W;
+        if (IN_EYE == m_impl->eyeHover)
+            return;
+        m_impl->eyeHover = IN_EYE;
+        m_impl->eyeText
+            ->rebuild() //
+            ->color([hover = IN_EYE] { return hover ? g_palette->m_colors.text : g_palette->m_colors.text.darken(0.4F); })
+            ->commence();
+    });
+
+    m_impl->listeners.mouseLeave = impl->m_externalEvents.mouseLeave.listen([this] {
+        if (!m_impl->eyeBg || !m_impl->eyeHover)
+            return;
+        m_impl->eyeHover = false;
+        m_impl->eyeText
+            ->rebuild() //
+            ->color([] { return g_palette->m_colors.text.darken(0.4F); })
+            ->commence();
+    });
 
     m_impl->listeners.mouseButton = impl->m_externalEvents.mouseButton.listen([this](Input::eMouseButton button, bool down) {
         if (!down)
@@ -778,6 +800,14 @@ bool CTextboxElement::acceptsMouseInput() {
 
 ePointerShape CTextboxElement::pointerShape() {
     return HT_POINTER_TEXT;
+}
+
+std::function<ePointerShape()> CTextboxElement::pointerShapeFn() {
+    return [this] {
+        if (m_impl->eyeBg && m_impl->lastCursorPos.x >= impl->position.w - STextboxImpl::EYE_W)
+            return HT_POINTER_POINTER;
+        return HT_POINTER_TEXT;
+    };
 }
 
 bool CTextboxElement::acceptsKeyboardInput() {

--- a/src/element/textbox/Textbox.hpp
+++ b/src/element/textbox/Textbox.hpp
@@ -42,6 +42,7 @@ namespace Hyprtoolkit {
 
         bool                               active            = false;
         bool                               firstAttachedPass = false;
+        bool                               eyeHover          = false;
 
         struct {
             CHyprSignalListener key;
@@ -49,6 +50,7 @@ namespace Hyprtoolkit {
             CHyprSignalListener leave;
             CHyprSignalListener mouseMove;
             CHyprSignalListener mouseButton;
+            CHyprSignalListener mouseLeave;
         } listeners;
 
         struct {


### PR DESCRIPTION
@vaxerski  follow up to #85.

when `eyeIcon(true)` is set, hovering over the icon now switches the cursor to `HT_POINTER_POINTER` and brightens the glyph from `text.darken(0.4)` to plain `text`. leaving the icon zone or the whole textbox resets it. uses the same `pointerShapeFn` mechanism `CTextElement` already uses for link hover, no new event wiring beyond a `mouseLeave` listener on the textbox.

i need this on the hyprpolkitagent side to close hyprwm/hyprpolkitagent#50, the password field's eye toggle currently has no affordance