### PR TITLE
element/textbox: vertically center single-line selection highlight

### DIFF
--- a/src/element/textbox/Textbox.cpp
+++ b/src/element/textbox/Textbox.cpp
@@ -605,7 +605,13 @@ void STextboxImpl::updateSelect() {
                             ->commence();
 
         selectBg->setPositionMode(IElement::HT_POSITION_ABSOLUTE);
-        selectBg->setAbsolutePosition(Vector2D{beginBox.x, beginBox.y});
+        if (!data.multiline) {
+            // single-line text is vertically centered (CTextElement::paint applies the VCENTER offset),
+            // but getCharBox y is relative to the layout top, so center the highlight to land on the glyphs.
+            selectBg->setPositionFlag(IElement::HT_POSITION_FLAG_VCENTER, true);
+            selectBg->setAbsolutePosition(Vector2D{beginBox.x, 0.F});
+        } else
+            selectBg->setAbsolutePosition(Vector2D{beginBox.x, beginBox.y});
 
         selectBgCont->addChild(selectBg);
         selectBgs.push_back(selectBg);

--- a/tests/unit/elements/Textbox.cpp
+++ b/tests/unit/elements/Textbox.cpp
@@ -2,6 +2,8 @@
 
 #include <element/textbox/Textbox.hpp>
 #include <hyprtoolkit/core/Backend.hpp>
+#include <hyprtoolkit/element/Null.hpp>
+#include <layout/Positioner.hpp>
 #include <xkbcommon/xkbcommon-keysyms.h>
 
 #include "../tricks/Tricks.hpp"
@@ -9,6 +11,7 @@
 #include "hyprtoolkit/core/Input.hpp"
 
 using namespace Hyprtoolkit;
+using namespace Hyprutils::Math;
 
 TEST(Element, textboxNavigation) {
     Tests::Tricks::createBackendSupport();
@@ -93,5 +96,48 @@ TEST(Element, textBoxNewLines) {
     textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.utf8 = "\r"});
     textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.utf8 = "\n"});
     EXPECT_EQ(textbox->currentText(), "I am on the first line!");
+    textbox.reset();
+}
+
+// a single-line textbox vertically centers its text, so the selection highlight must be
+// centered too. regression test for the highlight sitting above the glyphs.
+TEST(Element, textboxSingleLineSelectionVCentered) {
+    Tests::Tricks::createBackendSupport();
+
+    const CBox area = {{}, {300, 40}};
+
+    auto       root    = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {area.w, area.h}})->commence();
+    auto       textbox = CTextboxBuilder::begin()->defaultText("hunter2pw")->multiline(false)->commence();
+    root->addChild(textbox);
+
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    // select everything, then re-run the positioner so the freshly added highlight gets a box
+    textbox->impl->m_externalEvents.key.emit(Input::SKeyboardKeyEvent{.xkbKeysym = XKB_KEY_A, .modMask = Input::HT_MODIFIER_CTRL});
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    // walk to the highlight: textbox -> bg -> bgInnerCont -> selectBgCont -> selectBg.
+    // selectBgCont is the inner child that itself holds children (the text element has none).
+    auto         bg      = textbox->impl->children.at(0);
+    auto         bgInner = bg->impl->children.at(0);
+
+    SP<IElement> selectCont;
+    for (auto& c : bgInner->impl->children) {
+        if (!c->impl->children.empty())
+            selectCont = c;
+    }
+    ASSERT_TRUE(selectCont);
+    ASSERT_FALSE(selectCont->impl->children.empty());
+
+    const auto selBox = selectCont->impl->children.at(0)->impl->position;
+    const auto tbBox  = textbox->impl->position;
+
+    EXPECT_GT(selBox.w, 0.F); // the highlight spans the selected text
+    EXPECT_GT(selBox.h, 0.F);
+    // the highlight's vertical center lands on the textbox's vertical center
+    EXPECT_NEAR(selBox.y + selBox.h / 2.F, tbBox.y + tbBox.h / 2.F, 1.5F);
+
     textbox.reset();
 }


### PR DESCRIPTION
Single-line textboxes draw their text vertically centered (the `VCENTER` offset applied in `CTextElement::paint`), but the selection highlight was positioned at the pango layout top, so it sat above the glyphs instead of on them. Most visible on password fields.

Center the highlight to match when the textbox is single-line. Multiline selections are left alone since multiline text is top-aligned already.

Added a unit test that positions a single-line textbox, selects all with `Ctrl+A`, and asserts the highlight's vertical center lands on the textbox center. It fails without the fix.