### PR TITLE
element/scrollarea: add optional draggable scrollbar

### DIFF
--- a/include/hyprtoolkit/element/ScrollArea.hpp
+++ b/include/hyprtoolkit/element/ScrollArea.hpp
@@ -16,6 +16,7 @@ namespace Hyprtoolkit {
         Hyprutils::Memory::CSharedPointer<CScrollAreaBuilder>        scrollX(bool);
         Hyprutils::Memory::CSharedPointer<CScrollAreaBuilder>        scrollY(bool);
         Hyprutils::Memory::CSharedPointer<CScrollAreaBuilder>        blockUserScroll(bool);
+        Hyprutils::Memory::CSharedPointer<CScrollAreaBuilder>        showScrollbar(bool);
         Hyprutils::Memory::CSharedPointer<CScrollAreaBuilder>        size(CDynamicSize&&);
 
         Hyprutils::Memory::CSharedPointer<CScrollAreaElement>        commence();
@@ -40,11 +41,22 @@ namespace Hyprtoolkit {
         Hyprutils::Math::Vector2D                             getCurrentScroll();
         void                                                  setScroll(const Hyprutils::Math::Vector2D&);
 
+        // user children are routed into the inner scrolled layer
+        virtual void addChild(Hyprutils::Memory::CSharedPointer<IElement> child);
+        virtual void removeChild(Hyprutils::Memory::CSharedPointer<IElement> child);
+        virtual void clearChildren();
+
       private:
         CScrollAreaElement(const SScrollAreaData& data);
         static Hyprutils::Memory::CSharedPointer<CScrollAreaElement> create(const SScrollAreaData& data);
 
+        void                                                         init();
         void                                                         replaceData(const SScrollAreaData& data);
+
+        // builds or tears down the scrollbar elements to match showScrollbar
+        void rebuildScrollbars();
+        // sizes, places and shows/hides the scrollbars for the current scroll state
+        void                                                         layoutScrollbars();
 
         virtual void                                                 paint();
         virtual void                                                 reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize = {-1, -1});

--- a/src/element/scrollArea/Builder.cpp
+++ b/src/element/scrollArea/Builder.cpp
@@ -29,6 +29,11 @@ SP<CScrollAreaBuilder> CScrollAreaBuilder::blockUserScroll(bool x) {
     return m_self.lock();
 }
 
+SP<CScrollAreaBuilder> CScrollAreaBuilder::showScrollbar(bool x) {
+    m_data->showScrollbar = x;
+    return m_self.lock();
+}
+
 SP<CScrollAreaElement> CScrollAreaBuilder::commence() {
     if (m_element) {
         m_element->replaceData(*m_data);

--- a/src/element/scrollArea/ScrollArea.cpp
+++ b/src/element/scrollArea/ScrollArea.cpp
@@ -1,19 +1,64 @@
 #include "ScrollArea.hpp"
 #include <cmath>
+#include <algorithm>
+
+#include <hyprtoolkit/element/Null.hpp>
+#include <hyprtoolkit/element/Rectangle.hpp>
+#include <hyprtoolkit/palette/Palette.hpp>
 
 #include "../../layout/Positioner.hpp"
-#include "../../renderer/Renderer.hpp"
 #include "../../core/InternalBackend.hpp"
 #include "../../window/ToolkitWindow.hpp"
 
 #include "../Element.hpp"
 
 using namespace Hyprtoolkit;
+using namespace Hyprutils::Math;
+
+constexpr float SCROLLBAR_W   = 6.F;  // thickness of the bar
+constexpr float SCROLLBAR_PAD = 2.F;  // gap at each end of the track
+constexpr float SCROLLBAR_MIN = 24.F; // shortest the thumb is allowed to get
+constexpr float THUMB_IDLE_A  = 0.4F;
+constexpr float THUMB_HOT_A   = 0.7F;
+constexpr float TRACK_A       = 0.18F;
+
+// thumb gets brighter while hovered or dragged
+static void refreshThumbColor(SScrollbar& bar) {
+    if (!bar.thumb)
+        return;
+    const bool hot = bar.hovered || bar.dragging;
+    bar.thumb->rebuild()
+        ->color([hot] {
+            auto c = g_palette->m_colors.text;
+            c.a    = hot ? THUMB_HOT_A : THUMB_IDLE_A;
+            return c;
+        })
+        ->commence();
+}
+
+// map a pointer position along the track (strip-local, main axis) to a scroll offset
+static void scrollFromThumb(CScrollAreaElement& area, SScrollbar& bar, bool vertical, float mainAxisLocal) {
+    const float span = bar.trackLen - bar.thumbLen;
+    if (span <= 0.F || bar.maxOff <= 0.F)
+        return;
+
+    const float thumbOff = std::clamp(mainAxisLocal - bar.grab, SCROLLBAR_PAD, SCROLLBAR_PAD + span);
+    const float frac     = (thumbOff - SCROLLBAR_PAD) / span;
+
+    auto        scroll = area.getCurrentScroll();
+    if (vertical)
+        scroll.y = frac * bar.maxOff;
+    else
+        scroll.x = frac * bar.maxOff;
+
+    area.setScroll(scroll);
+}
 
 SP<CScrollAreaElement> CScrollAreaElement::create(const SScrollAreaData& data) {
     auto p          = SP<CScrollAreaElement>(new CScrollAreaElement(data));
     p->impl->self   = p;
     p->m_impl->self = p;
+    p->init();
     return p;
 }
 
@@ -44,12 +89,184 @@ CScrollAreaElement::CScrollAreaElement(const SScrollAreaData& data) : IElement()
     });
 }
 
+void CScrollAreaElement::init() {
+    m_impl->inner = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})->commence();
+    // the scroll offset rides on the inner layer's own position (an absolute offset), not a
+    // one-shot pass over its children. so any reposition of inner, including a bare one the
+    // window does when a content child schedules a reflow, keeps the content scrolled instead
+    // of snapping it back to the top.
+    m_impl->inner->setPositionMode(HT_POSITION_ABSOLUTE);
+    IElement::addChild(m_impl->inner);
+
+    rebuildScrollbars();
+}
+
+void CScrollAreaElement::rebuildScrollbars() {
+    const auto buildOne = [this](SScrollbar& bar, bool vertical) {
+        bar = SScrollbar{};
+
+        bar.strip = CNullBuilder::begin()
+                        ->size(vertical ? CDynamicSize{CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_PERCENT, {SCROLLBAR_W, 1.F}} :
+                                          CDynamicSize{CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_ABSOLUTE, {1.F, SCROLLBAR_W}})
+                        ->commence();
+        bar.strip->setPositionMode(HT_POSITION_ABSOLUTE);
+        bar.strip->setPositionFlag(vertical ? HT_POSITION_FLAG_RIGHT : HT_POSITION_FLAG_BOTTOM, true);
+        bar.strip->setReceivesMouse(true);
+
+        bar.track = CRectangleBuilder::begin()
+                        ->color([] {
+                            auto c = g_palette->m_colors.alternateBase;
+                            c.a    = TRACK_A;
+                            return c;
+                        })
+                        ->rounding(static_cast<int>(SCROLLBAR_W / 2.F))
+                        ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
+                        ->commence();
+
+        bar.thumb = CRectangleBuilder::begin()
+                        ->color([] {
+                            auto c = g_palette->m_colors.text;
+                            c.a    = THUMB_IDLE_A;
+                            return c;
+                        })
+                        ->rounding(static_cast<int>(SCROLLBAR_W / 2.F))
+                        ->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {SCROLLBAR_W, SCROLLBAR_W}})
+                        ->commence();
+        bar.thumb->setPositionMode(HT_POSITION_ABSOLUTE);
+
+        bar.strip->addChild(bar.track);
+        bar.strip->addChild(bar.thumb);
+
+        bar.listeners.move = bar.strip->impl->m_externalEvents.mouseMove.listen([this, &bar, vertical](const Vector2D& local) {
+            bar.lastLocal = local;
+            if (bar.dragging)
+                scrollFromThumb(*this, bar, vertical, vertical ? local.y : local.x);
+        });
+
+        bar.listeners.button = bar.strip->impl->m_externalEvents.mouseButton.listen([this, &bar, vertical](Input::eMouseButton button, bool down) {
+            if (button != Input::MOUSE_BUTTON_LEFT)
+                return;
+
+            if (!down) {
+                bar.dragging = false;
+                refreshThumbColor(bar);
+                return;
+            }
+
+            const float pos = vertical ? bar.lastLocal.y : bar.lastLocal.x;
+            if (pos >= bar.thumbOff && pos < bar.thumbOff + bar.thumbLen)
+                bar.grab = pos - bar.thumbOff; // grabbed the thumb where the cursor landed
+            else
+                bar.grab = bar.thumbLen / 2.F; // clicked the empty track, jump so the thumb centers under the cursor
+
+            bar.dragging = true;
+            refreshThumbColor(bar);
+            scrollFromThumb(*this, bar, vertical, pos);
+        });
+
+        bar.listeners.enter = bar.strip->impl->m_externalEvents.mouseEnter.listen([&bar](const Vector2D& local) {
+            bar.lastLocal = local;
+            bar.hovered   = true;
+            refreshThumbColor(bar);
+        });
+
+        bar.listeners.leave = bar.strip->impl->m_externalEvents.mouseLeave.listen([&bar] {
+            bar.hovered = false;
+            refreshThumbColor(bar);
+        });
+    };
+
+    if (m_impl->data.showScrollbar) {
+        buildOne(m_impl->vbar, true);
+        buildOne(m_impl->hbar, false);
+    } else {
+        if (m_impl->vbar.strip)
+            IElement::removeChild(m_impl->vbar.strip);
+        if (m_impl->hbar.strip)
+            IElement::removeChild(m_impl->hbar.strip);
+        m_impl->vbar = SScrollbar{};
+        m_impl->hbar = SScrollbar{};
+    }
+}
+
+void CScrollAreaElement::layoutScrollbars() {
+    const auto layoutOne = [this](SScrollbar& bar, bool vertical) {
+        if (!bar.strip)
+            return;
+
+        const auto  max    = m_impl->maxScroll();
+        const float maxOff = vertical ? max.y : max.x;
+        const bool  axisOn = vertical ? m_impl->data.scrollY : m_impl->data.scrollX;
+        const bool  want   = axisOn && maxOff > 0.F;
+
+        if (want && !bar.shown) {
+            IElement::addChild(bar.strip);
+            bar.shown = true;
+        } else if (!want && bar.shown) {
+            IElement::removeChild(bar.strip);
+            bar.shown = false;
+        }
+
+        if (!want)
+            return;
+
+        const CBox     view    = impl->position;
+        const Vector2D content = view.size() + max;
+
+        const float    viewLen = vertical ? view.h : view.w;
+        const float    contLen = vertical ? content.y : content.x;
+        const float    scroll  = vertical ? m_impl->data.currentScroll.y : m_impl->data.currentScroll.x;
+
+        bar.trackLen = viewLen - SCROLLBAR_PAD * 2.F;
+        if (bar.trackLen <= 0.F)
+            return; // viewport too small to draw a bar
+
+        bar.maxOff = maxOff;
+        // thumb wants to be the visible fraction of the track, but never shorter than the min,
+        // and never longer than the track itself (std::min/max, not clamp, so the order is always valid)
+        bar.thumbLen = std::min(bar.trackLen, std::max(SCROLLBAR_MIN, bar.trackLen * (viewLen / contLen)));
+        bar.thumbOff = SCROLLBAR_PAD + (scroll / maxOff) * (bar.trackLen - bar.thumbLen);
+
+        CBox stripBox;
+        CBox thumbBox;
+        if (vertical) {
+            stripBox = {view.x + view.w - SCROLLBAR_W, view.y, SCROLLBAR_W, view.h};
+            thumbBox = {stripBox.x, stripBox.y + bar.thumbOff, SCROLLBAR_W, bar.thumbLen};
+        } else {
+            stripBox = {view.x, view.y + view.h - SCROLLBAR_W, view.w, SCROLLBAR_W};
+            thumbBox = {stripBox.x + bar.thumbOff, stripBox.y, bar.thumbLen, SCROLLBAR_W};
+        }
+
+        g_positioner->position(bar.strip, stripBox); // also lays out the track (fills the strip)
+        g_positioner->position(bar.thumb, thumbBox);
+    };
+
+    layoutOne(m_impl->vbar, true);
+    layoutOne(m_impl->hbar, false);
+}
+
+void CScrollAreaElement::addChild(SP<IElement> child) {
+    m_impl->inner->addChild(child);
+}
+
+void CScrollAreaElement::removeChild(SP<IElement> child) {
+    m_impl->inner->removeChild(child);
+}
+
+void CScrollAreaElement::clearChildren() {
+    m_impl->inner->clearChildren();
+}
+
 void CScrollAreaElement::paint() {
-    ; // no-op
+    ; // no-op, the children draw themselves
 }
 
 void CScrollAreaElement::replaceData(const SScrollAreaData& data) {
-    m_impl->data = data;
+    const bool barChanged = m_impl->data.showScrollbar != data.showScrollbar;
+    m_impl->data          = data;
+
+    if (barChanged)
+        rebuildScrollbars();
 
     if (impl->window)
         impl->window->scheduleReposition(impl->self);
@@ -60,12 +277,16 @@ void CScrollAreaElement::reposition(const Hyprutils::Math::CBox& sbox, const Vec
 
     m_impl->clampMaxScroll();
 
-    g_positioner->positionChildren(impl->self.lock(),
-                                   {
-                                       .offset = -m_impl->data.currentScroll.round(),
-                                       .growX  = m_impl->data.scrollX,
-                                       .growY  = m_impl->data.scrollY,
-                                   });
+    // move the whole content layer by the scroll offset, then lay it (and the scrollbar
+    // strips) out. the strips carry no offset of their own, so they stay pinned to the edge.
+    m_impl->inner->setAbsolutePosition(-m_impl->data.currentScroll.round());
+    g_positioner->positionChildren(impl->self.lock());
+
+    // content is laid out at its natural size now, so this reads the real overflow.
+    m_impl->recalcMaxScroll();
+
+    if (m_impl->data.showScrollbar)
+        layoutScrollbars();
 }
 
 Vector2D CScrollAreaElement::size() {
@@ -108,19 +329,30 @@ bool CScrollAreaElement::positioningDependsOnChild() {
     return false;
 }
 
+Vector2D SScrollAreaImpl::maxScroll() {
+    return cachedMaxScroll;
+}
+
+void SScrollAreaImpl::recalcMaxScroll() {
+    if (inner->impl->children.empty() || !inner->impl->children.at(0)->impl->positionerData) {
+        cachedMaxScroll = {0, 0};
+        return;
+    }
+
+    cachedMaxScroll = (inner->impl->children.at(0)
+                           ->preferredSize({
+                               data.scrollX ? 99999999999 : self->impl->position.w,
+                               data.scrollY ? 99999999999 : self->impl->position.h,
+                           })
+                           .value_or(Vector2D{99999999, 99999999}) -
+                       self->impl->position.size())
+                          .clamp({0, 0});
+}
+
 void SScrollAreaImpl::clampMaxScroll() {
     // recheck limits
-    if (self->impl->children.empty() || !self->impl->children.at(0)->impl->positionerData)
+    if (inner->impl->children.empty() || !inner->impl->children.at(0)->impl->positionerData)
         return;
 
-    Vector2D scrollMax = (self->impl->children.at(0)
-                              ->preferredSize({
-                                  data.scrollX ? 99999999999 : self->impl->position.w,
-                                  data.scrollY ? 99999999999 : self->impl->position.h,
-                              })
-                              .value_or(Vector2D{99999999, 99999999}) -
-                          self->impl->position.size())
-                             .clamp({0, 0});
-
-    data.currentScroll = data.currentScroll.clamp({}, scrollMax);
+    data.currentScroll = data.currentScroll.clamp({}, maxScroll());
 }

--- a/src/element/scrollArea/ScrollArea.hpp
+++ b/src/element/scrollArea/ScrollArea.hpp
@@ -4,12 +4,43 @@
 #include "../../helpers/Signal.hpp"
 
 namespace Hyprtoolkit {
+    class CNullElement;
+    class CRectangleElement;
+
     struct SScrollAreaData {
         CDynamicSize              size            = CDynamicSize(CDynamicSize::HT_SIZE_AUTO, CDynamicSize::HT_SIZE_AUTO, {1, 1});
         bool                      scrollX         = false;
         bool                      scrollY         = false;
         bool                      blockUserScroll = false;
+        bool                      showScrollbar   = false;
         Hyprutils::Math::Vector2D currentScroll;
+    };
+
+    // one draggable scrollbar (track + thumb) living in the element tree, so it can take input
+    struct SScrollbar {
+        SP<CNullElement>      strip; // edge-anchored hit area that holds the track and thumb
+        SP<CRectangleElement> track;
+        SP<CRectangleElement> thumb;
+
+        bool                  shown    = false;
+        bool                  hovered  = false;
+        bool                  dragging = false;
+        float                 grab     = 0.F; // pointer offset inside the thumb when the drag started, in px
+
+        // geometry cached from the last layout, in the strip's local frame along the main axis;
+        // the input handlers reuse it so a click does not have to recompute the layout
+        float                     trackLen = 0.F;
+        float                     thumbOff = 0.F;
+        float                     thumbLen = 0.F;
+        float                     maxOff   = 0.F;
+        Hyprutils::Math::Vector2D lastLocal;
+
+        struct {
+            CHyprSignalListener button;
+            CHyprSignalListener move;
+            CHyprSignalListener enter;
+            CHyprSignalListener leave;
+        } listeners;
     };
 
     struct SScrollAreaImpl {
@@ -17,7 +48,21 @@ namespace Hyprtoolkit {
 
         WP<CScrollAreaElement> self;
 
+        SP<CNullElement>       inner; // content layer that actually scrolls; user children go here
+
+        SScrollbar             vbar;
+        SScrollbar             hbar;
+
         void                   clampMaxScroll();
+
+        // max scroll offset per axis, 0 on an axis whose content fits. cached so an off-frame
+        // clamp (a wheel event between layouts) does not re-measure the content mid-reflow and
+        // snap the scroll. recalcMaxScroll() refreshes it once per reposition once the content
+        // is laid out, maxScroll() just returns the cache.
+        Hyprutils::Math::Vector2D maxScroll();
+        void                      recalcMaxScroll();
+
+        Hyprutils::Math::Vector2D cachedMaxScroll;
 
         struct {
             CHyprSignalListener axis;

--- a/tests/Controls.cpp
+++ b/tests/Controls.cpp
@@ -139,7 +139,7 @@ int main(int argc, char** argv, char** envp) {
 
     window->m_rootElement->addChild(bg);
 
-    auto scroll = CScrollAreaBuilder::begin()->scrollY(true)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})->commence();
+    auto scroll = CScrollAreaBuilder::begin()->scrollY(true)->showScrollbar(true)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})->commence();
 
     mainLayout = CColumnLayoutBuilder::begin()->gap(3)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_AUTO, {0.7F, 1.F}})->commence();
 

--- a/tests/unit/elements/ScrollArea.cpp
+++ b/tests/unit/elements/ScrollArea.cpp
@@ -1,0 +1,242 @@
+#include <gtest/gtest.h>
+
+#include <hyprtoolkit/element/ScrollArea.hpp>
+#include <hyprtoolkit/element/Null.hpp>
+#include <hyprtoolkit/element/ColumnLayout.hpp>
+#include <hyprtoolkit/core/Backend.hpp>
+#include <hyprtoolkit/core/Input.hpp>
+#include <layout/Positioner.hpp>
+
+#include "../tricks/Tricks.hpp"
+#include "element/Element.hpp"
+
+using namespace Hyprtoolkit;
+using namespace Hyprutils::Math;
+
+// the scrollbar thumb is sized and placed from the max scroll offset, so the
+// clamp has to report the real content overflow. content 500 tall in a 100 tall
+// viewport means 400 of scroll, no more, no less.
+TEST(Element, scrollAreaClampsToContentOverflow) {
+    Tests::Tricks::createBackendSupport();
+
+    const CBox area = {{}, {200, 100}};
+
+    auto       root    = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {area.w, area.h}})->commence();
+    auto       scroll  = CScrollAreaBuilder::begin()->scrollY(true)->showScrollbar(true)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->commence();
+    auto       content = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {200, 500}})->commence();
+
+    scroll->addChild(content);
+    root->addChild(scroll);
+
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    // overscroll clamps to the overflow (500 - 100)
+    scroll->setScroll({0, 1000});
+    EXPECT_FLOAT_EQ(scroll->getCurrentScroll().y, 400.F);
+
+    // negative clamps to zero
+    scroll->setScroll({0, -50});
+    EXPECT_FLOAT_EQ(scroll->getCurrentScroll().y, 0.F);
+
+    // a valid offset is kept as-is
+    scroll->setScroll({0, 120});
+    EXPECT_FLOAT_EQ(scroll->getCurrentScroll().y, 120.F);
+
+    // x never scrolls (scrollX is off)
+    scroll->setScroll({300, 120});
+    EXPECT_FLOAT_EQ(scroll->getCurrentScroll().x, 0.F);
+
+    root.reset();
+}
+
+// the scrollbar is a real element in the tree now (so it can take input). its thumb
+// must be sized to the visible fraction and slide from top to bottom as you scroll.
+TEST(Element, scrollAreaThumbTracksScroll) {
+    Tests::Tricks::createBackendSupport();
+
+    const CBox area = {{}, {200, 100}};
+
+    auto       root    = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {area.w, area.h}})->commence();
+    auto       scroll  = CScrollAreaBuilder::begin()->scrollY(true)->showScrollbar(true)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->commence();
+    auto       content = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {200, 500}})->commence(); // 5x overflow
+
+    scroll->addChild(content);
+    root->addChild(scroll);
+
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    // children: [0] inner scrolled layer, [1] the shown vertical scrollbar strip
+    ASSERT_GE(scroll->impl->children.size(), 2u);
+    auto strip = scroll->impl->children.at(1);
+    // strip children: [0] track (fills the strip), [1] thumb
+    ASSERT_GE(strip->impl->children.size(), 2u);
+    auto       thumb = strip->impl->children.at(1);
+
+    const auto stripBox = strip->impl->position;
+    const auto top      = thumb->impl->position;
+
+    EXPECT_GT(top.h, 0.F);
+    EXPECT_LT(top.h, stripBox.h);               // 5x content -> thumb shorter than the track
+    EXPECT_NEAR(top.y, stripBox.y + 2.F, 1.0F); // at scroll 0 the thumb sits at the top (2px pad)
+
+    // scroll to the bottom: the thumb's bottom edge reaches the bottom of the track
+    scroll->setScroll({0, 400});
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    const auto bottom = strip->impl->children.at(1)->impl->position;
+    EXPECT_NEAR(bottom.y + bottom.h, stripBox.y + stripBox.h - 2.F, 1.5F);
+
+    root.reset();
+}
+
+// a viewport shorter than the minimum thumb length used to abort in std::clamp(x, min, track)
+// because track < min. the layout must survive it and keep the thumb within the track.
+TEST(Element, scrollAreaTinyViewportDoesNotCrash) {
+    Tests::Tricks::createBackendSupport();
+
+    const CBox area = {{}, {200, 20}}; // track length (20 - 4) is below the 24px min thumb
+
+    auto       root    = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {area.w, area.h}})->commence();
+    auto       scroll  = CScrollAreaBuilder::begin()->scrollY(true)->showScrollbar(true)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->commence();
+    auto       content = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {200, 500}})->commence();
+
+    scroll->addChild(content);
+    root->addChild(scroll);
+
+    g_positioner->position(root, area); // must not abort
+    g_positioner->positionChildren(root);
+
+    ASSERT_GE(scroll->impl->children.size(), 2u);
+    auto strip = scroll->impl->children.at(1);
+    ASSERT_GE(strip->impl->children.size(), 2u);
+    const auto thumb = strip->impl->children.at(1)->impl->position;
+
+    EXPECT_GT(thumb.h, 0.F);
+    EXPECT_LE(thumb.h, strip->impl->position.h); // thumb never exceeds the track
+
+    root.reset();
+}
+
+// the scrollbar is in the tree so it can take input: grabbing the thumb and dragging it
+// must move the scroll proportionally, and releasing must stop the drag.
+TEST(Element, scrollAreaThumbDragScrolls) {
+    Tests::Tricks::createBackendSupport();
+
+    const CBox area = {{}, {200, 100}};
+
+    auto       root    = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {area.w, area.h}})->commence();
+    auto       scroll  = CScrollAreaBuilder::begin()->scrollY(true)->showScrollbar(true)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->commence();
+    auto       content = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {200, 500}})->commence();
+
+    scroll->addChild(content);
+    root->addChild(scroll);
+
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    auto  strip = scroll->impl->children.at(1);
+    auto& ev    = strip->impl->m_externalEvents;
+
+    // geometry: track 96, thumb 24, thumb at top (offset 2) while scroll is 0
+    // press on the thumb (y=10, grab = 10-2 = 8), then drag the cursor to y=50
+    ev.mouseMove.emit(Vector2D{3, 10});
+    ev.mouseButton.emit(Input::MOUSE_BUTTON_LEFT, true);
+    EXPECT_FLOAT_EQ(scroll->getCurrentScroll().y, 0.F); // pressing where the thumb already is does not jump
+
+    ev.mouseMove.emit(Vector2D{3, 50});
+    // thumbOff target = 50 - 8 = 42; frac = (42 - 2) / (96 - 24); scroll = frac * 400
+    EXPECT_NEAR(scroll->getCurrentScroll().y, (40.F / 72.F) * 400.F, 1.0F);
+
+    // release, then move again: a non-dragging move must not scroll
+    ev.mouseButton.emit(Input::MOUSE_BUTTON_LEFT, false);
+    const float held = scroll->getCurrentScroll().y;
+    ev.mouseMove.emit(Vector2D{3, 90});
+    EXPECT_FLOAT_EQ(scroll->getCurrentScroll().y, held);
+
+    root.reset();
+}
+
+// regression: the scroll used to snap up and down while scrolling. the overflow was measured
+// live from the content's laid-out box, which the reposition flips between a natural and a
+// grown height within a frame. a layout child whose size tracks its parent then makes the
+// measured overflow differ depending on which state it is sampled in, so an off-frame clamp
+// (a wheel event) would yank the scroll to a wrong limit. the overflow is now cached from the
+// grown pass, so a stray relayout of just the content must not move the clamp.
+TEST(Element, scrollAreaMaxScrollIsStableAcrossContentRelayout) {
+    Tests::Tricks::createBackendSupport();
+
+    const CBox area = {{}, {200, 100}};
+
+    auto       root   = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {area.w, area.h}})->commence();
+    auto       scroll = CScrollAreaBuilder::begin()->scrollY(true)->showScrollbar(true)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->commence();
+
+    // a column whose preferred height depends on its own laid-out box: childSize measures each
+    // child against the column's stored position, so the percent-height child reports a
+    // different height when the column was last laid out grown vs natural.
+    auto content = CColumnLayoutBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_AUTO, {1, 1}})->commence();
+    content->addChild(CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {200, 400}})->commence());
+    content->addChild(CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_PERCENT, {200.F, 0.25F}})->commence());
+
+    scroll->addChild(content);
+    root->addChild(scroll);
+
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    // drive the scroll to its limit, record where the clamp lands
+    scroll->setScroll({0.F, 1'000'000'000.F});
+    const float bottom = scroll->getCurrentScroll().y;
+    EXPECT_GT(bottom, 0.F);
+
+    // a stray reflow of just the content layer (a window-level reflow can do this) leaves the
+    // content's stored box in a different state. re-clamping at the same offset must keep the
+    // scroll exactly where it was: the cached overflow does not follow the transient box.
+    auto inner = scroll->impl->children.at(0);
+    g_positioner->position(inner, inner->impl->position);
+
+    scroll->setScroll(scroll->getCurrentScroll());
+    EXPECT_FLOAT_EQ(scroll->getCurrentScroll().y, bottom);
+
+    root.reset();
+}
+
+// regression: scrolling down and then letting go snapped the content back to the top. when a
+// content child schedules a reflow, the window repositions the inner content layer on its own,
+// and the scroll offset used to live only in a one-shot pass over inner's children, so that
+// bare reposition dropped it (content jumped to y=0 while currentScroll stayed at the bottom).
+// the offset now rides on inner's own position, so a stray relayout keeps the content scrolled.
+TEST(Element, scrollAreaContentKeepsOffsetAcrossStrayRelayout) {
+    Tests::Tricks::createBackendSupport();
+
+    const CBox area = {{}, {200, 100}};
+
+    auto       root    = CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {area.w, area.h}})->commence();
+    auto       scroll  = CScrollAreaBuilder::begin()->scrollY(true)->showScrollbar(true)->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}})->commence();
+    auto       content = CColumnLayoutBuilder::begin()->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_AUTO, {1, 1}})->commence();
+    for (int i = 0; i < 6; ++i)
+        content->addChild(CNullBuilder::begin()->size({CDynamicSize::HT_SIZE_ABSOLUTE, CDynamicSize::HT_SIZE_ABSOLUTE, {200, 80}})->commence()); // 480 tall, overflow 380
+
+    scroll->addChild(content);
+    root->addChild(scroll);
+
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    // scroll to the bottom: the content layer rides up by the overflow
+    scroll->setScroll({0.F, 1000.F});
+    g_positioner->position(root, area);
+    g_positioner->positionChildren(root);
+
+    const float scrolled = content->impl->position.y;
+    EXPECT_LT(scrolled, -300.F); // shifted up by the ~380 overflow, not sitting at the top
+
+    // a bare reposition of the content layer, exactly what the window does when a content child
+    // schedules a reflow (a hover color rebuild, the gesture ending). the offset must survive it.
+    g_positioner->repositionNeeded(content);
+    EXPECT_FLOAT_EQ(content->impl->position.y, scrolled); // not snapped back to 0
+
+    root.reset();
+}


### PR DESCRIPTION
Redone as a real element in the tree, per your suggestion.

`showScrollbar(true)` adds a track and a draggable thumb. The scroll offset is applied to every child, so the content now lives in an inner layer that scrolls, and the scrollbar sits on top as a sibling that stays put. The strip takes mouse input:

- drag the thumb to scroll
- click the track to jump there and keep dragging
- thumb brightens on hover

Vertical and horizontal are both handled. The `paintOver()` hook from the first version is gone.

Tests (headless, hard assertions): scroll clamp, thumb size/position vs scroll, a tiny-viewport regression for a `std::clamp` abort that the first version hit, and a drag that asserts the scroll moves proportionally then stops on release.