### PR TITLE
tests/text: pin link color so the parse test is theme-independent

### DIFF
--- a/tests/unit/elements/Text.cpp
+++ b/tests/unit/elements/Text.cpp
@@ -2,6 +2,9 @@
 
 #include <element/text/Text.hpp>
 #include <hyprtoolkit/core/Backend.hpp>
+#include <hyprtoolkit/palette/Color.hpp>
+
+#include <core/InternalBackend.hpp>
 
 #include "../tricks/Tricks.hpp"
 
@@ -10,9 +13,12 @@ using namespace Hyprtoolkit;
 TEST(Element, text) {
     Tests::Tricks::createBackendSupport();
 
+    // pin the link color so the markup is deterministic regardless of the machine's theme
+    g_palette->m_colors.linkText = CHyprColor(1.F, 0.F, 0.F, 1.F);
+
     auto text = CTextBuilder::begin()->text(R"(Hello <a href="https://hypr.land">link</a>! Hi <a href="https://hypr.land">link2</a>!)")->commence();
 
-    EXPECT_EQ(text->m_impl->parsedText, "Hello <u><span foreground=\"#4eecf8ff\">link</span></u>! Hi <u><span foreground=\"#4eecf8ff\">link2</span></u>!");
+    EXPECT_EQ(text->m_impl->parsedText, "Hello <u><span foreground=\"#ff0000ff\">link</span></u>! Hi <u><span foreground=\"#ff0000ff\">link2</span></u>!");
 
     text.reset();
 }


### PR DESCRIPTION
`Element.text` asserted the default link color, but `CPalette::palette()` loads the machine theme, so the test failed on any setup with a custom accent. Pin `linkText` to a fixed color before parsing so the expected pango markup is deterministic.