### PR TITLE
core/wayland: route keyboard to the focused window, not the pointer one

### DIFF
--- a/src/core/platforms/WaylandPlatform.cpp
+++ b/src/core/platforms/WaylandPlatform.cpp
@@ -359,6 +359,16 @@ void CWaylandPlatform::initSeat() {
                 m_waylandState.seatState.repeatDelay = delay;
             });
 
+            // keyboard focus follows what the compositor focuses, not where the pointer is. without
+            // this a freshly opened dialog (e.g. a polkit prompt) gets no keys until the pointer
+            // enters it, so a programmatically focused field could not be typed into.
+            m_waylandState.keyboard->setEnter([this](CCWlKeyboard* r, uint32_t serial, wl_proxy* surf, wl_array* keys) {
+                if (auto w = windowForSurf(surf); w)
+                    m_keyboardWindow = w;
+            });
+
+            m_waylandState.keyboard->setLeave([this](CCWlKeyboard* r, uint32_t serial, wl_proxy* surf) { m_keyboardWindow.reset(); });
+
         } else if (!HAS_KEYBOARD && m_waylandState.keyboard)
             m_waylandState.keyboard.reset();
 
@@ -667,7 +677,7 @@ void CWaylandPlatform::onKey(uint32_t keycode, bool state) {
     else
         std::erase(m_waylandState.seatState.pressedKeys, keycode);
 
-    if (!m_currentWindow)
+    if (!m_keyboardWindow)
         return;
 
     Input::SKeyboardKeyEvent e;
@@ -680,7 +690,7 @@ void CWaylandPlatform::onKey(uint32_t keycode, bool state) {
         if (SYM == XKB_KEY_Left || SYM == XKB_KEY_Right || SYM == XKB_KEY_Up || SYM == XKB_KEY_Down) {
             // skip compose
             e.xkbKeysym = SYM;
-            m_currentWindow->keyboardKey(e);
+            m_keyboardWindow->keyboardKey(e);
             m_waylandState.seatState.repeatKeyEvent = e;
             startRepeatTimer();
             return;
@@ -701,7 +711,7 @@ void CWaylandPlatform::onKey(uint32_t keycode, bool state) {
         if (len > 1) {
             e.xkbKeysym = SYM;
             e.utf8      = std::string{buf, sc<size_t>(len - 1)};
-            m_currentWindow->keyboardKey(e);
+            m_keyboardWindow->keyboardKey(e);
             m_waylandState.seatState.repeatKeyEvent = e;
         }
 
@@ -713,15 +723,15 @@ void CWaylandPlatform::onKey(uint32_t keycode, bool state) {
         xkb_compose_state_reset(m_waylandState.seatState.xkbComposeState);
 
     m_waylandState.seatState.repeatKeyEvent = e;
-    m_currentWindow->keyboardKey(e);
+    m_keyboardWindow->keyboardKey(e);
     stopRepeatTimer();
 }
 
 void CWaylandPlatform::onRepeatTimerFire() {
-    if (!m_currentWindow)
+    if (!m_keyboardWindow)
         return;
 
-    m_currentWindow->keyboardKey(m_waylandState.seatState.repeatKeyEvent);
+    m_keyboardWindow->keyboardKey(m_waylandState.seatState.repeatKeyEvent);
 
     // add a repeat timer
     m_waylandState.seatState.repeatTimer =

--- a/src/core/platforms/WaylandPlatform.hpp
+++ b/src/core/platforms/WaylandPlatform.hpp
@@ -138,7 +138,8 @@ namespace Hyprtoolkit {
 
         std::vector<WP<CWaylandWindow>> m_windows;
         std::vector<WP<CWaylandLayer>>  m_layers;
-        WP<IWaylandWindow>              m_currentWindow;
+        WP<IWaylandWindow>              m_currentWindow;                    // window the pointer is over
+        WP<IWaylandWindow>              m_keyboardWindow;                   // window the compositor gave keyboard focus
         uint32_t                        m_currentMods                  = 0; // HT modifiers, not xkb
         uint32_t                        m_lastEnterSerial              = 0;
         // xdg_toplevel.resize requires the serial of a button PRESS, not release.


### PR DESCRIPTION
Keyboard input was delivered to whatever window the pointer was over. There was no `wl_keyboard.enter` handler, and `onKey` routed to `m_currentWindow`, which is set by pointer enter/leave.

The effect: a window that focuses an element on open (a polkit-style password dialog calling `focus()` after `open()`) received no keys until you moused over it and clicked. The compositor had given it keyboard focus, but the toolkit was looking at the pointer.

Track the keyboard-focused window from `wl_keyboard.enter`/`leave` (`m_keyboardWindow`) and route key events and key repeat there. Pointer events still use `m_currentWindow`.