### PR TITLE
element/text: fix size flicker at the ellipsize boundary

### DIFF
--- a/src/element/text/Text.cpp
+++ b/src/element/text/Text.cpp
@@ -32,6 +32,7 @@ CTextElement::CTextElement(const STextData& data) : IElement(), m_impl(makeUniqu
     m_impl->parseText();
     m_impl->lastFontSizeUnscaled = m_impl->data.fontSize.ptSize();
     m_impl->preferred            = m_impl->getTextSizePreferred();
+    m_impl->naturalSize          = m_impl->getNaturalSize();
 
     impl->m_externalEvents.mouseMove.listenStatic([this](const Vector2D& pos) {
         m_impl->lastCursorPos = pos;
@@ -54,7 +55,8 @@ void CTextElement::setText(std::string text) {
 
     m_impl->data.text = std::move(text);
     m_impl->parseText();
-    m_impl->preferred = m_impl->getTextSizePreferred();
+    m_impl->preferred   = m_impl->getTextSizePreferred();
+    m_impl->naturalSize = m_impl->getNaturalSize();
     m_impl->scheduleTexRefresh();
 
     if (impl->window)
@@ -70,6 +72,7 @@ void CTextElement::replaceData(const STextData& data) {
         m_impl->parseText();
         m_impl->lastFontSizeUnscaled = m_impl->data.fontSize.ptSize();
         m_impl->preferred            = m_impl->getTextSizePreferred();
+        m_impl->naturalSize          = m_impl->getNaturalSize();
         m_impl->scheduleTexRefresh();
     }
 
@@ -98,8 +101,11 @@ void CTextElement::paint() {
     }
 
     if ((impl->window && impl->window->scale() != m_impl->lastScale) || m_impl->needsTexRefresh) {
-        m_impl->lastScale = impl->window ? impl->window->scale() : 1.F;
-        m_impl->preferred = m_impl->getTextSizePreferred();
+        const bool SCALE_CHANGED = impl->window && impl->window->scale() != m_impl->lastScale;
+        m_impl->lastScale        = impl->window ? impl->window->scale() : 1.F;
+        m_impl->preferred        = m_impl->getTextSizePreferred();
+        if (SCALE_CHANGED)
+            m_impl->naturalSize = m_impl->getNaturalSize();
         if (!m_impl->resource)
             m_impl->renderTex();
         textureToUse = m_impl->oldTex;
@@ -133,7 +139,10 @@ void CTextElement::paint() {
 void CTextElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize) {
     IElement::reposition(box);
 
-    const auto DESIRED = m_impl->preferred;
+    // compare against the natural (unclamped) size, not the live preferred. the preferred
+    // shrinks when the text ellipsizes, which would let the layout hand it more room and grow
+    // it back, flip-flopping every frame at the boundary. the natural size does not move.
+    const auto DESIRED = m_impl->naturalSize;
     if (DESIRED.x > 0 && DESIRED.y > 0 && !m_impl->data.noEllipsize) {
         const auto PREV     = m_impl->lastMaxSize;
         m_impl->lastMaxSize = {-1, -1};
@@ -142,9 +151,11 @@ void CTextElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutils:
             m_impl->lastMaxSize.x = maxSize.x;
         if (maxSize.y > 0)
             m_impl->lastMaxSize.y = maxSize.y;
-        if (SIZE.x + 1 < DESIRED.x)
+        // ignore a degenerate, not-yet-laid-out box. clamping on a transient 0 would lock the
+        // text ellipsized forever, since the natural size never grows back to clear it.
+        if (SIZE.x > 1.F && SIZE.x + 1 < DESIRED.x)
             m_impl->lastMaxSize.x = SIZE.x;
-        if (SIZE.y + 1 < DESIRED.y)
+        if (SIZE.y > 1.F && SIZE.y + 1 < DESIRED.y)
             m_impl->lastMaxSize.y = SIZE.y;
 
         if (PREV != m_impl->lastMaxSize) {
@@ -269,6 +280,17 @@ Hyprutils::Math::Vector2D STextImpl::getTextSizePreferred() {
     cairo_destroy(CAIRO);
 
     return LAYOUTSIZE / lastScale;
+}
+
+// the text size with the dynamic ellipsize clamp removed. a user-set clampSize still applies.
+// reposition compares the allocated box against this stable value instead of the live, clamped
+// preferred, so a box at the fit/elide boundary cannot make the preferred flip every frame.
+Hyprutils::Math::Vector2D STextImpl::getNaturalSize() {
+    const auto SAVED = lastMaxSize;
+    lastMaxSize      = {-1, -1};
+    const auto SIZE  = getTextSizePreferred();
+    lastMaxSize      = SAVED;
+    return SIZE;
 }
 
 CBox STextImpl::getCharBox(size_t offset) {

--- a/src/element/text/Text.hpp
+++ b/src/element/text/Text.hpp
@@ -51,12 +51,16 @@ namespace Hyprtoolkit {
         SP<IRendererTexture>                                                                           oldTex; // while loading a new one
         ASP<Hyprgraphics::CTextResource>                                                               resource;
         Hyprutils::Math::Vector2D                                                                      size, preferred;
+        // the text's full size with no dynamic ellipsize clamp. stable across the fit/elide
+        // boundary, so the layout cannot flip-flop the preferred size every frame.
+        Hyprutils::Math::Vector2D                                                                      naturalSize;
 
         Hyprutils::Math::Vector2D                                                                      lastCursorPos;
 
         bool                                                                                           waitingForTex = false;
 
         Hyprutils::Math::Vector2D                                                                      getTextSizePreferred();
+        Hyprutils::Math::Vector2D                                                                      getNaturalSize();
         Hyprutils::Math::CBox                                                                          getCharBox(size_t offset);
         std::optional<size_t>                                                                          vecToOffset(const Hyprutils::Math::Vector2D& vec);
         float                                                                                          getCursorPos(size_t offset);

--- a/tests/unit/elements/Text.cpp
+++ b/tests/unit/elements/Text.cpp
@@ -5,10 +5,12 @@
 #include <hyprtoolkit/palette/Color.hpp>
 
 #include <core/InternalBackend.hpp>
+#include <layout/Positioner.hpp>
 
 #include "../tricks/Tricks.hpp"
 
 using namespace Hyprtoolkit;
+using namespace Hyprutils::Math;
 
 TEST(Element, text) {
     Tests::Tricks::createBackendSupport();
@@ -19,6 +21,32 @@ TEST(Element, text) {
     auto text = CTextBuilder::begin()->text(R"(Hello <a href="https://hypr.land">link</a>! Hi <a href="https://hypr.land">link2</a>!)")->commence();
 
     EXPECT_EQ(text->m_impl->parsedText, "Hello <u><span foreground=\"#ff0000ff\">link</span></u>! Hi <u><span foreground=\"#ff0000ff\">link2</span></u>!");
+
+    text.reset();
+}
+
+// regression: a text at the fit/elide boundary used to flicker between full and ellipsized
+// every frame, and a transient zero-width box (before the layout settles) could lock it
+// ellipsized forever. the clamp now compares against the stable natural size and ignores the
+// not-yet-laid-out box, so the text does not lock and recovers when room returns.
+TEST(Element, textEllipsizeRecoversAndDoesNotLock) {
+    Tests::Tricks::createBackendSupport();
+
+    auto        text    = CTextBuilder::begin()->text("Hello World Foo Bar Baz")->commence();
+    const float NATURAL = text->preferredSize({}).value_or(Vector2D{}).x;
+    EXPECT_GT(NATURAL, 20.F);
+
+    // a transient zero-width box (layout not settled yet) must not clamp the text
+    g_positioner->position(text, {{}, {0.F, 20.F}});
+    EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+
+    // a genuinely narrow box ellipsizes
+    g_positioner->position(text, {{}, {NATURAL / 2.F, 20.F}});
+    EXPECT_LT(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+
+    // room returns: the text recovers to its full size, no permanent ellipsis
+    g_positioner->position(text, {{}, {NATURAL + 80.F, 20.F}});
+    EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
 
     text.reset();
 }


### PR DESCRIPTION
the text preferred size could flip-flop between its full and ellipsized width every frame when a layout sat right at the fit/elide boundary. `reposition` compared the box against the live `preferred`, which shrinks when the text ellipsizes, so the layout then handed it more room and it grew back, and the texture-render `callback` rescheduled the whole thing each frame. it shows up as a constant flicker, e.g. a combobox value flipping between `According` and `Accor…`.

it compares against the text's natural (unclamped) size now, which does not move, so once it ellipsizes at a width it stays put. it also ignores a not-yet-laid-out zero box so a transient cannot lock the text ellipsized. this is the in-core version of the per-widget `clampSize` workaround.

reproduced live with the `controls` combobox: the value flipped 116 times in 3s at the boundary width, 5 after. added `Element.textEllipsizeRecoversAndDoesNotLock` for the transient-box lock (red without the guard).
