### PR TITLE
element/text: clamp ellipsize to the layout room hint, not the box

### DIFF
--- a/src/element/text/Text.cpp
+++ b/src/element/text/Text.cpp
@@ -32,7 +32,6 @@ CTextElement::CTextElement(const STextData& data) : IElement(), m_impl(makeUniqu
     m_impl->parseText();
     m_impl->lastFontSizeUnscaled = m_impl->data.fontSize.ptSize();
     m_impl->preferred            = m_impl->getTextSizePreferred();
-    m_impl->naturalSize          = m_impl->getNaturalSize();
 
     impl->m_externalEvents.mouseMove.listenStatic([this](const Vector2D& pos) {
         m_impl->lastCursorPos = pos;
@@ -55,8 +54,7 @@ void CTextElement::setText(std::string text) {
 
     m_impl->data.text = std::move(text);
     m_impl->parseText();
-    m_impl->preferred   = m_impl->getTextSizePreferred();
-    m_impl->naturalSize = m_impl->getNaturalSize();
+    m_impl->preferred = m_impl->getTextSizePreferred();
     m_impl->scheduleTexRefresh();
 
     if (impl->window)
@@ -72,7 +70,6 @@ void CTextElement::replaceData(const STextData& data) {
         m_impl->parseText();
         m_impl->lastFontSizeUnscaled = m_impl->data.fontSize.ptSize();
         m_impl->preferred            = m_impl->getTextSizePreferred();
-        m_impl->naturalSize          = m_impl->getNaturalSize();
         m_impl->scheduleTexRefresh();
     }
 
@@ -101,11 +98,8 @@ void CTextElement::paint() {
     }
 
     if ((impl->window && impl->window->scale() != m_impl->lastScale) || m_impl->needsTexRefresh) {
-        const bool SCALE_CHANGED = impl->window && impl->window->scale() != m_impl->lastScale;
-        m_impl->lastScale        = impl->window ? impl->window->scale() : 1.F;
-        m_impl->preferred        = m_impl->getTextSizePreferred();
-        if (SCALE_CHANGED)
-            m_impl->naturalSize = m_impl->getNaturalSize();
+        m_impl->lastScale = impl->window ? impl->window->scale() : 1.F;
+        m_impl->preferred = m_impl->getTextSizePreferred();
         if (!m_impl->resource)
             m_impl->renderTex();
         textureToUse = m_impl->oldTex;
@@ -139,10 +133,7 @@ void CTextElement::paint() {
 void CTextElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize) {
     IElement::reposition(box);
 
-    // compare against the natural (unclamped) size, not the live preferred. the preferred
-    // shrinks when the text ellipsizes, which would let the layout hand it more room and grow
-    // it back, flip-flopping every frame at the boundary. the natural size does not move.
-    const auto DESIRED = m_impl->naturalSize;
+    const auto DESIRED = m_impl->preferred;
     if (DESIRED.x > 0 && DESIRED.y > 0 && !m_impl->data.noEllipsize) {
         const auto PREV     = m_impl->lastMaxSize;
         m_impl->lastMaxSize = {-1, -1};
@@ -151,11 +142,13 @@ void CTextElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutils:
             m_impl->lastMaxSize.x = maxSize.x;
         if (maxSize.y > 0)
             m_impl->lastMaxSize.y = maxSize.y;
-        // ignore a degenerate, not-yet-laid-out box. clamping on a transient 0 would lock the
-        // text ellipsized forever, since the natural size never grows back to clear it.
-        if (SIZE.x > 1.F && SIZE.x + 1 < DESIRED.x)
+        // clamp to the layout's available-room hint (maxSize), already applied above. only fall
+        // back to the actual box when no hint was given: an auto-sized label's box equals its own
+        // (clamped) preferred and feeds back, flip-flopping at the boundary, whereas the room hint
+        // is stable and reflects the real container, so the text settles and recovers.
+        if (maxSize.x <= 0 && SIZE.x + 1 < DESIRED.x)
             m_impl->lastMaxSize.x = SIZE.x;
-        if (SIZE.y > 1.F && SIZE.y + 1 < DESIRED.y)
+        if (maxSize.y <= 0 && SIZE.y + 1 < DESIRED.y)
             m_impl->lastMaxSize.y = SIZE.y;
 
         if (PREV != m_impl->lastMaxSize) {
@@ -280,17 +273,6 @@ Hyprutils::Math::Vector2D STextImpl::getTextSizePreferred() {
     cairo_destroy(CAIRO);
 
     return LAYOUTSIZE / lastScale;
-}
-
-// the text size with the dynamic ellipsize clamp removed. a user-set clampSize still applies.
-// reposition compares the allocated box against this stable value instead of the live, clamped
-// preferred, so a box at the fit/elide boundary cannot make the preferred flip every frame.
-Hyprutils::Math::Vector2D STextImpl::getNaturalSize() {
-    const auto SAVED = lastMaxSize;
-    lastMaxSize      = {-1, -1};
-    const auto SIZE  = getTextSizePreferred();
-    lastMaxSize      = SAVED;
-    return SIZE;
 }
 
 CBox STextImpl::getCharBox(size_t offset) {

--- a/src/element/text/Text.hpp
+++ b/src/element/text/Text.hpp
@@ -51,16 +51,12 @@ namespace Hyprtoolkit {
         SP<IRendererTexture>                                                                           oldTex; // while loading a new one
         ASP<Hyprgraphics::CTextResource>                                                               resource;
         Hyprutils::Math::Vector2D                                                                      size, preferred;
-        // the text's full size with no dynamic ellipsize clamp. stable across the fit/elide
-        // boundary, so the layout cannot flip-flop the preferred size every frame.
-        Hyprutils::Math::Vector2D                                                                      naturalSize;
 
         Hyprutils::Math::Vector2D                                                                      lastCursorPos;
 
         bool                                                                                           waitingForTex = false;
 
         Hyprutils::Math::Vector2D                                                                      getTextSizePreferred();
-        Hyprutils::Math::Vector2D                                                                      getNaturalSize();
         Hyprutils::Math::CBox                                                                          getCharBox(size_t offset);
         std::optional<size_t>                                                                          vecToOffset(const Hyprutils::Math::Vector2D& vec);
         float                                                                                          getCursorPos(size_t offset);

--- a/tests/unit/elements/Text.cpp
+++ b/tests/unit/elements/Text.cpp
@@ -25,27 +25,59 @@ TEST(Element, text) {
     text.reset();
 }
 
-// regression: a text at the fit/elide boundary used to flicker between full and ellipsized
-// every frame, and a transient zero-width box (before the layout settles) could lock it
-// ellipsized forever. the clamp now compares against the stable natural size and ignores the
-// not-yet-laid-out box, so the text does not lock and recovers when room returns.
-TEST(Element, textEllipsizeRecoversAndDoesNotLock) {
+// an auto label gets no room hint and its box tracks its own clamped preferred, so the box feeds
+// back into the next layout. a transient narrow box on first layout (e.g. before an async icon
+// sibling reflows the row) must not lock the text ellipsized: once the box equals the clamped
+// preferred the clamp has to release and the text recover. #94 compared the box against a cached
+// natural size, so the box-feedback condition stayed true and the ellipsis locked forever. this is
+// the hyprlauncher regression.
+TEST(Element, textEllipsizeRecoversFromTransientClamp) {
+    Tests::Tricks::createBackendSupport();
+
+    auto text = CTextBuilder::begin()->text("Hello World Foo Bar Baz")->commence();
+
+    // natural width: a generous box, no room hint
+    g_positioner->position(text, {{}, {1000.F, 20.F}}, {-1.F, -1.F});
+    const float NATURAL = text->preferredSize({}).value_or(Vector2D{}).x;
+    EXPECT_GT(NATURAL, 40.F);
+
+    // a transient narrow box on first layout clamps it
+    g_positioner->position(text, {{}, {NATURAL * 0.3F, 20.F}}, {-1.F, -1.F});
+    EXPECT_LT(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+
+    // from here the layout hands the auto label a box equal to its own preferred. feed that back a
+    // few frames: it must converge back to NATURAL, not stay locked at the clamped width.
+    for (int i = 0; i < 4; ++i) {
+        const auto PREF = text->preferredSize({}).value_or(Vector2D{});
+        g_positioner->position(text, {{}, PREF}, {-1.F, -1.F});
+    }
+    EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+
+    text.reset();
+}
+
+// a stable room hint (e.g. the combobox row layout) clamps to the room and stays put, no per-frame
+// flicker at the fit/elide boundary.
+TEST(Element, textEllipsizeStableUnderRoomHint) {
     Tests::Tricks::createBackendSupport();
 
     auto        text    = CTextBuilder::begin()->text("Hello World Foo Bar Baz")->commence();
     const float NATURAL = text->preferredSize({}).value_or(Vector2D{}).x;
     EXPECT_GT(NATURAL, 20.F);
 
-    // a transient zero-width box (layout not settled yet) must not clamp the text
-    g_positioner->position(text, {{}, {0.F, 20.F}});
-    EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+    const CBox     widebox = {{}, {NATURAL, 20.F}};
+    const Vector2D tight   = {NATURAL * 0.4F, 20.F};
 
-    // a genuinely narrow box ellipsizes
-    g_positioner->position(text, {{}, {NATURAL / 2.F, 20.F}});
-    EXPECT_LT(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+    g_positioner->position(text, widebox, tight);
+    const float CLAMPED = text->preferredSize({}).value_or(Vector2D{}).x;
+    EXPECT_LT(CLAMPED, NATURAL);
 
-    // room returns: the text recovers to its full size, no permanent ellipsis
-    g_positioner->position(text, {{}, {NATURAL + 80.F, 20.F}});
+    // same room again does not flip the size
+    g_positioner->position(text, widebox, tight);
+    EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, CLAMPED);
+
+    // room grows back: recover to full
+    g_positioner->position(text, widebox, {NATURAL + 80.F, 20.F});
     EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
 
     text.reset();


### PR DESCRIPTION
#94 fixed the boundary flicker by caching a natural size and comparing the text box against it. that settles the combobox, but it regressed hyprlauncher: every entry locked to an ellipsized state on first run and never recovered (reported by tekstryder on #94).

the cause is the cache plus a box that tracks its own preferred. an auto label's box equals its clamped preferred, so once a transient narrow box on first layout clamps the text, the box stays narrow, the cached natural size keeps comparing against it, and the text can never grow back.

this drops the natural-size cache and clamps to the layout's available-room hint (`maxSize`) instead. the room hint is stable across frames, so the size settles and the flicker is gone, and it reflects the real container, so the text recovers once there is room. texts positioned with no room hint keep the old box-based clamp, so nothing else changes.

verified the combobox value still settles cleanly at the fit/elide boundary with no jitter, and hyprlauncher renders full entry names again instead of locking to `Bra...` / `Firef...`. added a positioner test that clamps to the room hint, stays stable on a repeat layout, and recovers to the natural size when the room grows.
