### PR TITLE
Re-render CImageElements on fitMode change

### DIFF
--- a/src/element/image/Image.cpp
+++ b/src/element/image/Image.cpp
@@ -68,9 +68,7 @@ void CImageElement::renderTex() {
     const auto CACHE_STR = m_impl->getCacheString();
 
     const auto ASSET = Asset::assetCache()->get(CACHE_STR);
-	
-	// If using different fitMode value don't use cached asset 
-    if (ASSET && ASSET->tex() && ASSET->tex()->fitMode() == m_impl->data.fitMode) {
+    if (ASSET) {
         g_logger->log(HT_LOG_DEBUG, "CImageElement: path {} was already cached, reusing entry", m_impl->data.path);
         m_impl->failed     = false;
         m_impl->cacheEntry = ASSET;
@@ -172,9 +170,11 @@ std::string SImageImpl::getCacheString() {
         return std::format("data-{:x}", rc<uintptr_t>(data.data.data()));
 
     if (!data.icon)
-        return data.path.ends_with(".svg") ? std::format("{}-{}x{}", data.path, preferredSvgSize().x, preferredSvgSize().y) : data.path;
+        return data.path.ends_with(".svg") ? std::format("{}-{}x{}-{}", data.path, preferredSvgSize().x, preferredSvgSize().y, sc<int>(data.fitMode)) :
+                                             std::format("{}-{}", data.path, sc<int>(data.fitMode));
     else
-        return std::format("icon-{}-{}x{}", reinterpretPointerCast<CSystemIconDescription>(data.icon)->m_bestPath, preferredSvgSize().x, preferredSvgSize().y);
+        return std::format("icon-{}-{}x{}-{}", reinterpretPointerCast<CSystemIconDescription>(data.icon)->m_bestPath, preferredSvgSize().x, preferredSvgSize().y,
+                           sc<int>(data.fitMode));
 }
 
 SP<CImageBuilder> CImageElement::rebuild() {

--- a/src/element/image/Image.cpp
+++ b/src/element/image/Image.cpp
@@ -68,7 +68,9 @@ void CImageElement::renderTex() {
     const auto CACHE_STR = m_impl->getCacheString();
 
     const auto ASSET = Asset::assetCache()->get(CACHE_STR);
-    if (ASSET) {
+	
+	// If using different fitMode value don't use cached asset 
+    if (ASSET && ASSET->tex() && ASSET->tex()->fitMode() == m_impl->data.fitMode) {
         g_logger->log(HT_LOG_DEBUG, "CImageElement: path {} was already cached, reusing entry", m_impl->data.path);
         m_impl->failed     = false;
         m_impl->cacheEntry = ASSET;

--- a/tests/unit/elements/Image.cpp
+++ b/tests/unit/elements/Image.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include <element/image/Image.hpp>
+#include <hyprgraphics/resource/resources/ImageResource.hpp>
+
+using namespace Hyprtoolkit;
+
+// the cache key has to encode the fit mode, otherwise two elements sharing a path but rendering
+// with different fit modes collide on one cached texture (the texture bakes in the fit mode). this
+// is the hyprpaper "same image, two monitors, different fit_mode" bug.
+TEST(Element, imageCacheStringEncodesFitMode) {
+    SImageImpl a, b;
+    a.data.path = b.data.path = "wallpaper.png";
+
+    a.data.fitMode = IMAGE_FIT_MODE_COVER;
+    b.data.fitMode = IMAGE_FIT_MODE_STRETCH;
+    EXPECT_NE(a.getCacheString(), b.getCacheString());
+
+    b.data.fitMode = IMAGE_FIT_MODE_COVER;
+    EXPECT_EQ(a.getCacheString(), b.getCacheString());
+}


### PR DESCRIPTION
When calling to set a Hyprpaper wallpaper with Hyprctl using the same image path but a different `fit_mode` value for two monitors one after the other, it eventually fails because of a lack of a check in `CImageElement` for cached assets.
This PR attempts to fix that by simply comparing the `fitMode` values to decide if the asset should be reused or instead rerendered.

I'm sorry if this is not correct fully, the correct solution to the overall problem, or up to a standard for this library since I don't know it well at all.