### PR TITLE
element/image: include the fit mode in the cache key

### DIFF
--- a/src/element/image/Image.cpp
+++ b/src/element/image/Image.cpp
@@ -170,9 +170,11 @@ std::string SImageImpl::getCacheString() {
         return std::format("data-{:x}", rc<uintptr_t>(data.data.data()));
 
     if (!data.icon)
-        return data.path.ends_with(".svg") ? std::format("{}-{}x{}", data.path, preferredSvgSize().x, preferredSvgSize().y) : data.path;
+        return data.path.ends_with(".svg") ? std::format("{}-{}x{}-{}", data.path, preferredSvgSize().x, preferredSvgSize().y, sc<int>(data.fitMode)) :
+                                             std::format("{}-{}", data.path, sc<int>(data.fitMode));
     else
-        return std::format("icon-{}-{}x{}", reinterpretPointerCast<CSystemIconDescription>(data.icon)->m_bestPath, preferredSvgSize().x, preferredSvgSize().y);
+        return std::format("icon-{}-{}x{}-{}", reinterpretPointerCast<CSystemIconDescription>(data.icon)->m_bestPath, preferredSvgSize().x, preferredSvgSize().y,
+                           sc<int>(data.fitMode));
 }
 
 SP<CImageBuilder> CImageElement::rebuild() {

--- a/tests/unit/elements/Image.cpp
+++ b/tests/unit/elements/Image.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include <element/image/Image.hpp>
+#include <hyprgraphics/resource/resources/ImageResource.hpp>
+
+using namespace Hyprtoolkit;
+
+// the cache key has to encode the fit mode, otherwise two elements sharing a path but rendering
+// with different fit modes collide on one cached texture (the texture bakes in the fit mode). this
+// is the hyprpaper "same image, two monitors, different fit_mode" bug.
+TEST(Element, imageCacheStringEncodesFitMode) {
+    SImageImpl a, b;
+    a.data.path = b.data.path = "wallpaper.png";
+
+    a.data.fitMode = IMAGE_FIT_MODE_COVER;
+    b.data.fitMode = IMAGE_FIT_MODE_STRETCH;
+    EXPECT_NE(a.getCacheString(), b.getCacheString());
+
+    b.data.fitMode = IMAGE_FIT_MODE_COVER;
+    EXPECT_EQ(a.getCacheString(), b.getCacheString());
+}


### PR DESCRIPTION
the cached texture bakes in the fit mode, but the cache key was just the path (plus the svg/icon size), so two image elements sharing a path with different fit modes collided on one cache entry and the second drew with the first's fit. shows up with hyprpaper putting one image on two monitors with different fit_mode.

`CAssetCache::get` matches by `source()` equality and `getCacheString` omitted the fit mode, so the second element reused the first's texture (`fitMode` is baked in at `uploadTexture`). appending `sc<int>(data.fitMode)` to the key gives each fit mode its own entry while keeping in-flight dedup for elements that share path and fit mode.

`STextureData` carries only `resource` and `fitMode`, so that one field is the whole class; `rounding` and alpha are draw-time shader uniforms and need no key change.

added a unit test asserting the key differs across fit modes and matches for the same one. alternative to #96, which guarded the cache hit instead of the key.

build-tested + unit suite (37/37); the two-monitor pixel repro needs two outputs.