### PR TITLE
window: add keyboard shortcuts inhibitor option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ protocolnew("stable/tablet" "tablet-v2" false)
 protocolnew("unstable/text-input" "text-input-unstable-v3" false)
 protocolnew("staging/linux-drm-syncobj" "linux-drm-syncobj-v1" false)
 protocolnew("protocols" "wlr-layer-shell-unstable-v1" true)
+protocolnew("unstable/keyboard-shortcuts-inhibit" "keyboard-shortcuts-inhibit-unstable-v1" false)
 
 # Tests
 if(BUILD_TESTING)
@@ -162,6 +163,10 @@ if(BUILD_TESTING)
   add_executable(simpleSessionLock "tests/SimpleSessionLock.cpp")
   target_link_libraries(simpleSessionLock PRIVATE PkgConfig::deps hyprtoolkit)
   add_dependencies(tests simpleSessionLock)
+
+  add_executable(shortcutsInhibit "tests/ShortcutsInhibit.cpp")
+  target_link_libraries(shortcutsInhibit PRIVATE PkgConfig::deps hyprtoolkit)
+  add_dependencies(tests shortcutsInhibit)
 
   add_executable(accentButton "tests/AccentButton.cpp")
   target_link_libraries(accentButton PRIVATE PkgConfig::deps hyprtoolkit)

--- a/include/hyprtoolkit/window/Window.hpp
+++ b/include/hyprtoolkit/window/Window.hpp
@@ -45,11 +45,11 @@ namespace Hyprtoolkit {
         Hyprutils::Memory::CSharedPointer<CWindowBuilder>        maxSize(const Hyprutils::Math::Vector2D&);
 
         // only for HT_WINDOW_TOPLEVEL: opt into edge-drag resize and resize cursors
-        Hyprutils::Memory::CSharedPointer<CWindowBuilder>        resizable(bool);
+        Hyprutils::Memory::CSharedPointer<CWindowBuilder> resizable(bool);
 
         // only for HT_WINDOW_TOPLEVEL: window follows the root element's preferred
         // size whenever the layout changes. requires an AUTO-sized root element.
-        Hyprutils::Memory::CSharedPointer<CWindowBuilder>        autosize(bool);
+        Hyprutils::Memory::CSharedPointer<CWindowBuilder> autosize(bool);
 
         // only for LAYER and LOCK_SURFACE
         Hyprutils::Memory::CSharedPointer<CWindowBuilder> prefferedOutput(const Hyprutils::Memory::CSharedPointer<IOutput>& output);
@@ -62,6 +62,10 @@ namespace Hyprtoolkit {
         Hyprutils::Memory::CSharedPointer<CWindowBuilder> exclusiveEdge(uint32_t);
         Hyprutils::Memory::CSharedPointer<CWindowBuilder> exclusiveZone(int32_t);
         Hyprutils::Memory::CSharedPointer<CWindowBuilder> kbInteractive(uint32_t);
+
+        // only for HT_WINDOW_TOPLEVEL: request a keyboard shortcuts inhibitor so the compositor does
+        // not fire its global keybinds while this window is focused. useful for modal prompts.
+        Hyprutils::Memory::CSharedPointer<CWindowBuilder> inhibitShortcuts(bool);
 
         // only for HT_WINDOW_POPUP
         Hyprutils::Memory::CSharedPointer<CWindowBuilder> parent(const Hyprutils::Memory::CSharedPointer<IWindow>& parent);
@@ -90,12 +94,12 @@ namespace Hyprtoolkit {
         // authority over xdg_toplevel size and may ignore, clamp, or override.
         // listen on m_events.resized for the size the compositor actually applied.
         // no-op for layer, lock, popup.
-        virtual void                      setSize(const Hyprutils::Math::Vector2D& size) {}
+        virtual void setSize(const Hyprutils::Math::Vector2D& size) {}
 
         // hand off to the compositor for an interactive edge/corner resize.
         // must be called from a pointer-press handler so the latest button
         // serial is fresh. no-op for layer, lock, popup.
-        virtual void                      startInteractiveResize(eResizeEdge edges) {}
+        virtual void startInteractiveResize(eResizeEdge edges) {}
 
         struct {
             // coordinates here are logical, meaning pixel size is this * scale()

--- a/src/core/platforms/WaylandPlatform.cpp
+++ b/src/core/platforms/WaylandPlatform.cpp
@@ -114,8 +114,11 @@ bool CWaylandPlatform::attempt() {
                 (wl_proxy*)wl_registry_bind((wl_registry*)m_waylandState.registry->resource(), id, &ext_session_lock_manager_v1_interface, 1));
         } else if (NAME == wl_data_device_manager_interface.name) {
             TRACE(g_logger->log(HT_LOG_TRACE, "  > binding to global: {} (version {}) with id {}", name, 3, id));
-            m_waylandState.dataDeviceManager = makeShared<CCWlDataDeviceManager>(
-                (wl_proxy*)wl_registry_bind((wl_registry*)m_waylandState.registry->resource(), id, &wl_data_device_manager_interface, 3));
+            m_waylandState.dataDeviceManager =
+                makeShared<CCWlDataDeviceManager>((wl_proxy*)wl_registry_bind((wl_registry*)m_waylandState.registry->resource(), id, &wl_data_device_manager_interface, 3));
+        } else if (NAME == zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) {
+            m_waylandState.shortcutsInhibitMgr = makeShared<CCZwpKeyboardShortcutsInhibitManagerV1>(
+                (wl_proxy*)wl_registry_bind((wl_registry*)m_waylandState.registry->resource(), id, &zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1));
         }
     });
     m_waylandState.registry->setGlobalRemove([this](CCWlRegistry* r, uint32_t id) {
@@ -485,7 +488,7 @@ void CWaylandPlatform::setClipboard(const std::string& text) {
     m_waylandState.currentSource->sendOffer("UTF8_STRING");
 
     m_waylandState.currentSource->setSend([this](CCWlDataSource*, const char* /*mime*/, int32_t fd) {
-        const auto& s = m_waylandState.currentSourceText;
+        const auto& s    = m_waylandState.currentSourceText;
         size_t      sent = 0;
         while (sent < s.size()) {
             ssize_t n = write(fd, s.data() + sent, s.size() - sent);
@@ -521,7 +524,7 @@ std::string CWaylandPlatform::readClipboard() {
     close(fds[1]);
     wl_display_roundtrip(m_waylandState.display);
 
-    std::string         out;
+    std::string            out;
     std::array<char, 4096> buf{};
     for (;;) {
         const ssize_t N = read(fds[0], buf.data(), buf.size());

--- a/src/core/platforms/WaylandPlatform.hpp
+++ b/src/core/platforms/WaylandPlatform.hpp
@@ -25,6 +25,7 @@
 #include <wlr-layer-shell-unstable-v1.hpp>
 #include <linux-drm-syncobj-v1.hpp>
 #include <ext-session-lock-v1.hpp>
+#include <keyboard-shortcuts-inhibit-unstable-v1.hpp>
 
 #include <aquamarine/allocator/GBM.hpp>
 #include <aquamarine/backend/Misc.hpp>
@@ -77,30 +78,31 @@ namespace Hyprtoolkit {
             wl_display* display = nullptr;
 
             // hw-s types
-            Hyprutils::Memory::CSharedPointer<CCWlRegistry>                 registry;
-            Hyprutils::Memory::CSharedPointer<CCWlSeat>                     seat;
-            Hyprutils::Memory::CSharedPointer<CCWlShm>                      shm;
-            Hyprutils::Memory::CSharedPointer<CCXdgWmBase>                  xdg;
-            Hyprutils::Memory::CSharedPointer<CCWlCompositor>               compositor;
-            Hyprutils::Memory::CSharedPointer<CCZwpLinuxDmabufV1>           dmabuf;
-            Hyprutils::Memory::CSharedPointer<CCZwpLinuxDmabufFeedbackV1>   dmabufFeedback;
-            Hyprutils::Memory::CSharedPointer<CCWpFractionalScaleManagerV1> fractional;
-            Hyprutils::Memory::CSharedPointer<CCWpViewporter>               viewporter;
-            Hyprutils::Memory::CSharedPointer<CCWlKeyboard>                 keyboard;
-            Hyprutils::Memory::CSharedPointer<CCWlPointer>                  pointer;
-            Hyprutils::Memory::CSharedPointer<CCWpCursorShapeManagerV1>     cursorShapeMgr;
-            Hyprutils::Memory::CSharedPointer<CCWpCursorShapeDeviceV1>      cursorShapeDev;
-            Hyprutils::Memory::CSharedPointer<CCZwpTextInputManagerV3>      textInputManager;
-            Hyprutils::Memory::CSharedPointer<CCZwpTextInputV3>             textInput;
-            Hyprutils::Memory::CSharedPointer<CCZwlrLayerShellV1>           layerShell;
-            Hyprutils::Memory::CSharedPointer<CCWpLinuxDrmSyncobjManagerV1> syncobj;
-            Hyprutils::Memory::CSharedPointer<CCExtSessionLockManagerV1>    sessionLock;
-            Hyprutils::Memory::CSharedPointer<CCWlDataDeviceManager>        dataDeviceManager;
-            Hyprutils::Memory::CSharedPointer<CCWlDataDevice>               dataDevice;
-            std::vector<Hyprutils::Memory::CSharedPointer<CCWlDataOffer>>   pendingOffers;
-            Hyprutils::Memory::CSharedPointer<CCWlDataOffer>                currentOffer;
-            Hyprutils::Memory::CSharedPointer<CCWlDataSource>               currentSource;
-            std::string                                                     currentSourceText;
+            Hyprutils::Memory::CSharedPointer<CCWlRegistry>                           registry;
+            Hyprutils::Memory::CSharedPointer<CCWlSeat>                               seat;
+            Hyprutils::Memory::CSharedPointer<CCWlShm>                                shm;
+            Hyprutils::Memory::CSharedPointer<CCXdgWmBase>                            xdg;
+            Hyprutils::Memory::CSharedPointer<CCWlCompositor>                         compositor;
+            Hyprutils::Memory::CSharedPointer<CCZwpLinuxDmabufV1>                     dmabuf;
+            Hyprutils::Memory::CSharedPointer<CCZwpLinuxDmabufFeedbackV1>             dmabufFeedback;
+            Hyprutils::Memory::CSharedPointer<CCWpFractionalScaleManagerV1>           fractional;
+            Hyprutils::Memory::CSharedPointer<CCWpViewporter>                         viewporter;
+            Hyprutils::Memory::CSharedPointer<CCWlKeyboard>                           keyboard;
+            Hyprutils::Memory::CSharedPointer<CCWlPointer>                            pointer;
+            Hyprutils::Memory::CSharedPointer<CCWpCursorShapeManagerV1>               cursorShapeMgr;
+            Hyprutils::Memory::CSharedPointer<CCWpCursorShapeDeviceV1>                cursorShapeDev;
+            Hyprutils::Memory::CSharedPointer<CCZwpTextInputManagerV3>                textInputManager;
+            Hyprutils::Memory::CSharedPointer<CCZwpTextInputV3>                       textInput;
+            Hyprutils::Memory::CSharedPointer<CCZwlrLayerShellV1>                     layerShell;
+            Hyprutils::Memory::CSharedPointer<CCWpLinuxDrmSyncobjManagerV1>           syncobj;
+            Hyprutils::Memory::CSharedPointer<CCExtSessionLockManagerV1>              sessionLock;
+            Hyprutils::Memory::CSharedPointer<CCZwpKeyboardShortcutsInhibitManagerV1> shortcutsInhibitMgr;
+            Hyprutils::Memory::CSharedPointer<CCWlDataDeviceManager>                  dataDeviceManager;
+            Hyprutils::Memory::CSharedPointer<CCWlDataDevice>                         dataDevice;
+            std::vector<Hyprutils::Memory::CSharedPointer<CCWlDataOffer>>             pendingOffers;
+            Hyprutils::Memory::CSharedPointer<CCWlDataOffer>                          currentOffer;
+            Hyprutils::Memory::CSharedPointer<CCWlDataSource>                         currentSource;
+            std::string                                                               currentSourceText;
 
             // control
             bool initialized  = false;
@@ -138,14 +140,14 @@ namespace Hyprtoolkit {
 
         std::vector<WP<CWaylandWindow>> m_windows;
         std::vector<WP<CWaylandLayer>>  m_layers;
-        WP<IWaylandWindow>              m_currentWindow;                    // window the pointer is over
-        WP<IWaylandWindow>              m_keyboardWindow;                   // window the compositor gave keyboard focus
-        uint32_t                        m_currentMods                  = 0; // HT modifiers, not xkb
-        uint32_t                        m_lastEnterSerial              = 0;
+        WP<IWaylandWindow>              m_currentWindow;       // window the pointer is over
+        WP<IWaylandWindow>              m_keyboardWindow;      // window the compositor gave keyboard focus
+        uint32_t                        m_currentMods     = 0; // HT modifiers, not xkb
+        uint32_t                        m_lastEnterSerial = 0;
         // xdg_toplevel.resize requires the serial of a button PRESS, not release.
-        uint32_t                        m_lastPointerButtonPressSerial = 0;
+        uint32_t                     m_lastPointerButtonPressSerial = 0;
 
-        WP<CWaylandSessionLockState>    m_sessionLockState;
+        WP<CWaylandSessionLockState> m_sessionLockState;
     };
 
     inline UP<CWaylandPlatform> g_waylandPlatform;

--- a/src/window/Builder.cpp
+++ b/src/window/Builder.cpp
@@ -102,6 +102,11 @@ SP<CWindowBuilder> CWindowBuilder::kbInteractive(uint32_t x) {
     return m_self.lock();
 }
 
+SP<CWindowBuilder> CWindowBuilder::inhibitShortcuts(bool x) {
+    m_data->inhibitShortcuts = x;
+    return m_self.lock();
+}
+
 SP<IWindow> CWindowBuilder::commence() {
     switch (m_data->type) {
         case HT_WINDOW_POPUP:

--- a/src/window/IWaylandWindow.hpp
+++ b/src/window/IWaylandWindow.hpp
@@ -16,6 +16,7 @@
 #include <viewporter.hpp>
 #include <text-input-unstable-v3.hpp>
 #include <linux-drm-syncobj-v1.hpp>
+#include <keyboard-shortcuts-inhibit-unstable-v1.hpp>
 
 #include <chrono>
 
@@ -74,6 +75,7 @@ namespace Hyprtoolkit {
 
         struct {
             SP<CCWlSurface>                         surface;
+            SP<CCZwpKeyboardShortcutsInhibitorV1>   shortcutsInhibitor;
             SP<CCXdgSurface>                        xdgSurface;
             SP<CCXdgToplevel>                       xdgToplevel;
             SP<CCWlCallback>                        frameCallback;
@@ -86,9 +88,9 @@ namespace Hyprtoolkit {
             Hyprutils::Math::Vector2D               size;
             Hyprutils::Math::Vector2D               logicalSize;
             float                                   appliedScale = 1.F;
-            SP<CCWpFractionalScaleV1>               fractional = nullptr;
-            SP<CCWpViewport>                        viewport   = nullptr;
-            uint32_t                                serial     = 0;
+            SP<CCWpFractionalScaleV1>               fractional   = nullptr;
+            SP<CCWpViewport>                        viewport     = nullptr;
+            uint32_t                                serial       = 0;
 
             std::optional<Hyprutils::Math::CRegion> lastOpaqueRegion;
         } m_waylandState;

--- a/src/window/WaylandWindow.cpp
+++ b/src/window/WaylandWindow.cpp
@@ -41,6 +41,10 @@ void CWaylandWindow::open() {
         return;
     }
 
+    if (m_creationData.inhibitShortcuts && g_waylandPlatform->m_waylandState.shortcutsInhibitMgr && g_waylandPlatform->m_waylandState.seat)
+        m_waylandState.shortcutsInhibitor = makeShared<CCZwpKeyboardShortcutsInhibitorV1>(
+            g_waylandPlatform->m_waylandState.shortcutsInhibitMgr->sendInhibitShortcuts(m_waylandState.surface->resource(), g_waylandPlatform->m_waylandState.seat->resource()));
+
     m_waylandState.xdgSurface = makeShared<CCXdgSurface>(g_waylandPlatform->m_waylandState.xdg->sendGetXdgSurface(m_waylandState.surface->resource()));
 
     if (!m_waylandState.xdgSurface->resource()) {

--- a/src/window/Window.hpp
+++ b/src/window/Window.hpp
@@ -13,6 +13,7 @@ namespace Hyprtoolkit {
         std::optional<Hyprutils::Math::Vector2D> maxSize;
         bool                                     resizable         = false;
         bool                                     autosize          = false;
+        bool                                     inhibitShortcuts  = false;
         std::string                              title             = "Hyprtoolkit App";
         std::string                              class_            = "hyprtoolkit-app";
         uint32_t                                 prefferedOutputId = 0;

--- a/tests/ShortcutsInhibit.cpp
+++ b/tests/ShortcutsInhibit.cpp
@@ -1,0 +1,40 @@
+#include <hyprtoolkit/core/Backend.hpp>
+#include <hyprtoolkit/window/Window.hpp>
+#include <hyprtoolkit/element/Rectangle.hpp>
+#include <hyprtoolkit/element/Text.hpp>
+
+#include <hyprutils/memory/SharedPtr.hpp>
+
+#include <print>
+#include <string_view>
+
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::Math;
+using namespace Hyprtoolkit;
+
+#define SP CSharedPointer
+
+static SP<IBackend> backend;
+
+// focus this window, then press a keybind bound to e.g. cyclenext. with the inhibitor on, focus
+// must not move. pass "off" for the negative control (focus should cycle as normal).
+int main(int argc, char** argv) {
+    const bool inhibit = !(argc > 1 && std::string_view{argv[1]} == "off");
+
+    backend = IBackend::create();
+
+    auto window =
+        CWindowBuilder::begin()->preferredSize({440, 160})->appTitle("shortcuts inhibit test")->appClass("hyprtoolkit-shortcuts-inhibit")->inhibitShortcuts(inhibit)->commence();
+
+    window->m_rootElement->addChild(CRectangleBuilder::begin()->color([] { return CHyprColor{0.1F, 0.1F, 0.1F}; })->commence());
+    window->m_rootElement->addChild(CTextBuilder::begin()
+                                        ->text(inhibit ? "inhibit ON: keybinds should not fire while focused" : "inhibit OFF (control): keybinds fire")
+                                        ->color([] { return CHyprColor{0.9F, 0.9F, 0.9F}; })
+                                        ->commence());
+
+    std::println("shortcuts inhibitor requested: {}", inhibit ? "ON" : "OFF (control)");
+
+    window->open();
+    backend->enterLoop();
+    return 0;
+}


### PR DESCRIPTION
adds `CWindowBuilder::inhibitShortcuts(bool)`. when set on a toplevel, the window requests a `zwp_keyboard_shortcuts_inhibitor_v1` for its surface, so the compositor stops firing its global keybinds while the window is focused. defaults off, no behavior change for existing windows.

the motivating case is a modal prompt (the polkit dialog) that must not lose keyboard focus to a focus-cycle keybind while the user is typing a password. the compositor focus-gates the inhibitor itself (`isInhibited()` is true only while the inhibitor's surface is focused), so the toolkit creates it once for the surface and does no focus tracking.

plumbing: vendor the protocol, bind the manager global at version 1, and store the inhibitor on the window so it lives with the surface and is released on teardown. the protocol is standard (also in sway and kwin); on a compositor that does not advertise the manager the guard no-ops.

verified on Hyprland: a toplevel built with `inhibitShortcuts(true)` keeps focus when a `cyclenext` keybind fires while it is focused, an identical window without the flag cycles as normal, and after the inhibit window closes the keybind works again. `tests/ShortcutsInhibit.cpp` opens such a window (pass `off` for the control).
