### PR TITLE
fix : update scanner api calls from proxy() to resource()

### DIFF
--- a/src/window/IWaylandWindow.cpp
+++ b/src/window/IWaylandWindow.cpp
@@ -126,7 +126,7 @@ void IWaylandWindow::prepareExplicit(SP<CWaylandBuffer> buffer) {
         return;
 
     if (!m_waylandState.syncobjSurf)
-        m_waylandState.syncobjSurf = makeShared<CCWpLinuxDrmSyncobjSurfaceV1>(g_waylandPlatform->m_waylandState.syncobj->sendGetSurface(m_waylandState.surface->proxy()));
+        m_waylandState.syncobjSurf = makeShared<CCWpLinuxDrmSyncobjSurfaceV1>(g_waylandPlatform->m_waylandState.syncobj->sendGetSurface(m_waylandState.surface->resource()));
 
     auto sync = g_renderer->exportSync(buffer->m_buffer.lock());
 

--- a/src/window/WaylandLayer.cpp
+++ b/src/window/WaylandLayer.cpp
@@ -72,10 +72,10 @@ void CWaylandLayer::open() {
     wl_proxy* outputProxy = nullptr;
     if (m_creationData.prefferedOutputId) {
         if (auto output = g_waylandPlatform->outputForHandle(m_creationData.prefferedOutputId); output)
-            outputProxy = output->m_wlOutput->proxy();
+            outputProxy = output->m_wlOutput->resource();
     }
     m_layerState.layerSurface = makeShared<CCZwlrLayerSurfaceV1>(g_waylandPlatform->m_waylandState.layerShell->sendGetLayerSurface(
-        m_waylandState.surface->proxy(), outputProxy, sc<zwlrLayerShellV1Layer>(m_creationData.layer), m_creationData.class_.c_str()));
+        m_waylandState.surface->resource(), outputProxy, sc<zwlrLayerShellV1Layer>(m_creationData.layer), m_creationData.class_.c_str()));
 
     if (!m_layerState.layerSurface->resource()) {
         g_logger->log(HT_LOG_ERROR, "layer opening failed: no ls resource. Errno: {}", errno);


### PR DESCRIPTION
Recent upstream changes to `hyprwayland-scanner` unified the protocol wrapper object interface, changing the client-side `.proxy()` method to `.resource()`. 

This patch updates the calls inside `IWaylandWindow.cpp` and `WaylandLayer.cpp` to resolve the resulting compilation failures. Tested and verified working via GitHub Actions. 