### PR TITLE
window/layer: implement set size

### DIFF
--- a/src/window/WaylandLayer.cpp
+++ b/src/window/WaylandLayer.cpp
@@ -142,3 +142,12 @@ void CWaylandLayer::render() {
 
     IWaylandWindow::render();
 }
+
+void CWaylandLayer::setSize(const Hyprutils::Math::Vector2D& size) {
+    if (m_waylandState.logicalSize == size)
+        return;
+
+    m_layerState.layerSurface->sendSetSize(size.x, size.y);
+
+    configure(size, 0);
+}

--- a/src/window/WaylandLayer.hpp
+++ b/src/window/WaylandLayer.hpp
@@ -2,6 +2,7 @@
 
 #include "IWaylandWindow.hpp"
 #include <wlr-layer-shell-unstable-v1.hpp>
+#include <hyprutils/math/Vector2D.hpp>
 
 namespace Hyprtoolkit {
 
@@ -13,6 +14,7 @@ namespace Hyprtoolkit {
         virtual void close();
         virtual void open();
         virtual void render();
+        virtual void setSize(const Hyprutils::Math::Vector2D& size);
 
       private:
         SWindowCreationData m_creationData;


### PR DESCRIPTION
Implements the `setSize` method (from #81) for layer shell windows. 