### PR TITLE
fix: Fix crash when explicit sync export fails

### DIFF
--- a/src/window/IWaylandWindow.cpp
+++ b/src/window/IWaylandWindow.cpp
@@ -130,6 +130,11 @@ void IWaylandWindow::prepareExplicit(SP<CWaylandBuffer> buffer) {
 
     auto sync = g_renderer->exportSync(buffer->m_buffer.lock());
 
+    if (!sync) {
+        g_logger->log(HT_LOG_ERROR, "wayland: failed to export sync timeline in prepareExplicit");
+        return;
+    }
+
     if (!buffer->m_waylandState.syncTimeline) {
         buffer->m_waylandState.syncTimeline = makeShared<CCWpLinuxDrmSyncobjTimelineV1>(g_waylandPlatform->m_waylandState.syncobj->sendImportTimeline(sync->m_syncobjFD.get()));
         buffer->m_timeline                  = sync;
@@ -147,6 +152,11 @@ void IWaylandWindow::submitExplicit(SP<CWaylandBuffer> buffer) {
     auto sync = g_renderer->exportSync(buffer->m_buffer.lock());
 
     sync->m_releasePoint = sync->m_acquirePoint + 1;
+
+    if (!sync) {
+        g_logger->log(HT_LOG_ERROR, "wayland: failed to export sync timeline in submitExplicit");
+        return;
+    }
 
     TRACE(g_logger->log(HT_LOG_TRACE, "wayland: Submitting points acq: {}, rel: {} for ES", sync->m_acquirePoint, sync->m_releasePoint));
 


### PR DESCRIPTION
Fix a possible crash in IWaylandWindow::prepareExplicit() when exportSync() fails and returns nullptr.

Add the same check to IWaylandWindow::submitExplicit().

Crash description:
hyprpaper crashed ~1h after hypridle triggered hyprlock and DPMS was disabled. The exact trigger is unknown, but the crash happens due to the missing nullptr handling.

Backrace:
```
#0  Hyprutils::OS::CFileDescriptor::get (this=0x4)
    at /usr/src/debug/hyprutils/hyprutils-0.13.1/src/os/FileDescriptor.cpp:32
#1  0xADDR in Hyprtoolkit::IWaylandWindow::prepareExplicit (this=this@entry=0xADDR,
    buffer=...)
    at /usr/src/debug/hyprtoolkit/hyprtoolkit-0.5.4/src/window/IWaylandWindow.cpp:135
#2  0xADDR in Hyprtoolkit::IWaylandWindow::render (this=0xADDR)
    at /usr/src/debug/hyprtoolkit/hyprtoolkit-0.5.4/src/window/IWaylandWindow.cpp:181
#3  0xADDR in std::function<void()>::operator() (this=<optimized out>)
    at /usr/include/c++/16.1.1/bits/std_function.h:581
#4  Hyprtoolkit::CBackend::enterLoop (this=0xADDR)
    at /usr/src/debug/hyprtoolkit/hyprtoolkit-0.5.4/src/core/Backend.cpp:501
#5  0xADDR in CUI::run (this=0xADDR)
    at /usr/src/debug/hyprpaper/hyprpaper-0.8.4/src/ui/UI.cpp:192
#6  main (argc=<optimized out>, argv=<optimized out>, envp=<optimized out>)
    at /usr/src/debug/hyprpaper/hyprpaper-0.8.4/src/main.cpp:47
```