### PR TITLE
layout: increment used space when an element shrinks or grows

### DIFF
--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -112,6 +112,7 @@ namespace Hyprtoolkit::LinearLayout {
 
                 // squeeze the last element in
                 sizes.at(i) = MAX - used;
+                used = MAX;
                 continue;
             }
 
@@ -130,6 +131,7 @@ namespace Hyprtoolkit::LinearLayout {
                 if (!grows(C.at(i)))
                     continue;
                 sizes.at(i) += MAX - used;
+                used = MAX;
                 break;
             }
         }


### PR DESCRIPTION
The amount of space used is not updated when an element has to be shrunk or it is grown at the end. This can cause issues when an element grows if an element is shrunk, because the element is grown beyond the bounds of the layout. Growing an element is less problematic, but it does mean an incorrect max size is reported to children.