### PR TITLE
Revert "layout: increment used space when an element must be shrunk or grown (#108)"

### DIFF
--- a/src/element/LinearLayout.hpp
+++ b/src/element/LinearLayout.hpp
@@ -112,7 +112,6 @@ namespace Hyprtoolkit::LinearLayout {
 
                 // squeeze the last element in
                 sizes.at(i) = MAX - used;
-                used = MAX;
                 continue;
             }
 
@@ -131,7 +130,6 @@ namespace Hyprtoolkit::LinearLayout {
                 if (!grows(C.at(i)))
                     continue;
                 sizes.at(i) += MAX - used;
-                used = MAX;
                 break;
             }
         }


### PR DESCRIPTION
This reverts commit 5e04a821cd0ebceb9bc508a58e2faeaca389bfa5.

This caused on issue with the controls test with text layouts. Text layouts are based on max size reported, not by the actual size the layout has requested (#95). Anything that uses `stretchLayout` in controls is broken because the central gap is filled by a null element. Previously, the text grew anyway because the max size ignored the growth of the null element (the text was drawn over the null element) but this changed meant the text would be ellipsized. I didn't catch this because this is part of a bigger change into text layouts that isn't ready yet and I (stupidly) didn't test the change independently. For now, this should be reverted.