### PR TITLE
Fix constant rerender bug in icons

### DIFF
--- a/src/element/image/Image.cpp
+++ b/src/element/image/Image.cpp
@@ -41,7 +41,7 @@ void CImageElement::paint() {
     if (impl->window)
         m_impl->lastScale = impl->window->scale();
 
-    if (m_impl->data.icon && m_impl->preferredSvgSize() != m_impl->size && !m_impl->waitingForTex) {
+    if (m_impl->data.icon && m_impl->data.icon->scalable() && m_impl->preferredSvgSize() != m_impl->size && !m_impl->waitingForTex) {
         renderTex();
         assetToUse = m_impl->oldCacheEntry;
     }

--- a/src/system/Icons.hpp
+++ b/src/system/Icons.hpp
@@ -33,6 +33,7 @@ namespace Hyprtoolkit {
         struct SIconCacheResult {
             bool                  badIcon = true;
             std::filesystem::path path;
+            bool                  scalable = false;
         };
 
         /*

--- a/src/system/SystemIcon.cpp
+++ b/src/system/SystemIcon.cpp
@@ -15,6 +15,7 @@ CSystemIconDescription::CSystemIconDescription(const std::string& name) {
 
     if (const auto CK = g_iconFactory->getCached(name); CK) {
         m_bestPath = CK->badIcon ? "" : CK->path;
+        m_scalable = CK->badIcon ? false : CK->scalable;
         return;
     }
 
@@ -24,10 +25,13 @@ CSystemIconDescription::CSystemIconDescription(const std::string& name) {
         std::filesystem::path fullDirPath = lookupDir + "/";
 
         auto                  iconPath = fullDirPath / (name + ".svg");
+        m_scalable = true;
         std::error_code       ec;
 
-        if (!std::filesystem::exists(iconPath, ec) || ec)
+        if (!std::filesystem::exists(iconPath, ec) || ec) {
             iconPath = fullDirPath / (name + ".png");
+            m_scalable = false;
+        }
 
         if (!std::filesystem::exists(iconPath, ec) || ec)
             continue;
@@ -42,17 +46,19 @@ CSystemIconDescription::CSystemIconDescription(const std::string& name) {
         std::error_code ec;
         if (std::filesystem::exists("/usr/share/pixmaps/" + name + ".svg", ec) && !ec) {
             found      = true;
+            m_scalable = true;
             m_bestPath = "/usr/share/pixmaps/" + name + ".svg";
         }
 
         if (!found && std::filesystem::exists("/usr/share/pixmaps/" + name + ".png", ec) && !ec) {
             found      = true;
+            m_scalable = false;
             m_bestPath = "/usr/share/pixmaps/" + name + ".png";
         }
     }
 
     if (found)
-        g_iconFactory->cacheEntry(name, CSystemIconFactory::SIconCacheResult{.badIcon = false, .path = m_bestPath});
+        g_iconFactory->cacheEntry(name, CSystemIconFactory::SIconCacheResult{.badIcon = false, .path = m_bestPath, .scalable = m_scalable});
     else
         g_iconFactory->cacheEntry(name, CSystemIconFactory::SIconCacheResult{});
 }


### PR DESCRIPTION
- **icons: populate the scalable variable**
- **image: don't rerender a non scalable icon when size changes**

Currently, if an icon texture is not the exact size of the element, it is
rerendered every frame, which is the correct behavior for svg icons, but not png
or other types.
