### PR TITLE
Make popups work on layer shells and fix incorrect cast

### DIFF
--- a/src/window/IWaylandWindow.cpp
+++ b/src/window/IWaylandWindow.cpp
@@ -239,7 +239,7 @@ void IWaylandWindow::setCursor(ePointerShape shape) {
 }
 
 SP<IWindow> IWaylandWindow::openPopup(const SWindowCreationData& data) {
-    auto x    = makeShared<CWaylandPopup>(data, reinterpretPointerCast<CWaylandWindow>(m_self.lock()));
+    auto x    = makeShared<CWaylandPopup>(data, reinterpretPointerCast<IWaylandWindow>(m_self.lock()));
     x->m_self = x;
     m_popups.emplace_back(x);
     return x;

--- a/src/window/WaylandPopup.cpp
+++ b/src/window/WaylandPopup.cpp
@@ -15,7 +15,7 @@
 using namespace Hyprtoolkit;
 using namespace Hyprutils::Math;
 
-CWaylandPopup::CWaylandPopup(const SWindowCreationData& data, SP<CWaylandWindow> window) : m_parent(window), m_creationData(data) {
+CWaylandPopup::CWaylandPopup(const SWindowCreationData& data, SP<IWaylandWindow> window) : m_parent(window), m_creationData(data) {
     m_rootElement = CNullBuilder::begin()->commence();
 }
 

--- a/src/window/WaylandPopup.cpp
+++ b/src/window/WaylandPopup.cpp
@@ -1,5 +1,6 @@
 #include "WaylandPopup.hpp"
 #include "WaylandWindow.hpp"
+#include "WaylandLayer.hpp"
 
 #include <hyprtoolkit/element/Null.hpp>
 
@@ -64,6 +65,9 @@ void CWaylandPopup::open() {
         (xdgPositionerConstraintAdjustment)(XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X));
 
     m_wlPopupState.xdgPopup = makeShared<CCXdgPopup>(m_waylandState.xdgSurface->sendGetPopup(m_parent->m_waylandState.xdgSurface.get(), m_wlPopupState.xdgPositioner.get()));
+
+    if (dynamicPointerCast<CWaylandLayer>(m_parent))
+        dynamicPointerCast<CWaylandLayer>(m_parent)->m_layerState.layerSurface->sendGetPopup(m_wlPopupState.xdgPopup->resource());
 
     if (!m_wlPopupState.xdgPopup->resource()) {
         g_logger->log(HT_LOG_ERROR, "window opening failed: no xdgToplevel given. Errno: {}", errno);

--- a/src/window/WaylandPopup.hpp
+++ b/src/window/WaylandPopup.hpp
@@ -9,7 +9,7 @@ namespace Hyprtoolkit {
     // TODO: de-dup this shit
     class CWaylandPopup : public IWaylandWindow {
       public:
-        CWaylandPopup(const SWindowCreationData& data, SP<CWaylandWindow> parent);
+        CWaylandPopup(const SWindowCreationData& data, SP<IWaylandWindow> parent);
         virtual ~CWaylandPopup();
 
         virtual void                                       close();
@@ -17,7 +17,7 @@ namespace Hyprtoolkit {
         virtual Hyprutils::Memory::CSharedPointer<IWindow> openPopup(const SWindowCreationData& data);
 
       private:
-        WP<CWaylandWindow>  m_parent;
+        WP<IWaylandWindow>  m_parent;
         SWindowCreationData m_creationData;
 
         struct {


### PR DESCRIPTION
This changes the parent window type of popups to be `IWaylandWindow` not `CWaylandWindow`. The parent was already set by casting an `IWaylandWindow` to a `CWaylandWindow`, which is incorrect for layer shells which are `IWaylandWindow` but not `CWaylandWindow`. The popup doesn't actually need anything from `CWaylandWindow` so changing the type doesn't change any behavior.

Then making layer shells work is a simple change to call get popup on the layer shell after making the popup.