### PR TITLE
layout: don't compute child sizes twice per pass

### DIFF
--- a/src/element/columnLayout/ColumnLayout.cpp
+++ b/src/element/columnLayout/ColumnLayout.cpp
@@ -51,10 +51,10 @@ Hyprutils::Math::Vector2D CColumnLayoutElement::size() {
 }
 
 Hyprutils::Math::Vector2D CColumnLayoutElement::childSize(Hyprutils::Memory::CSharedPointer<IElement> child) {
-    if (child->preferredSize(impl->position.size()))
-        return *child->preferredSize(impl->position.size());
-    else if (child->minimumSize(impl->position.size()))
-        return *child->minimumSize(impl->position.size());
+    if (const auto PREFERRED = child->preferredSize(impl->position.size()); PREFERRED)
+        return *PREFERRED;
+    if (const auto MINIMUM = child->minimumSize(impl->position.size()); MINIMUM)
+        return *MINIMUM;
     return {-1, -1};
 }
 
@@ -66,8 +66,9 @@ std::optional<Hyprutils::Math::Vector2D> CColumnLayoutElement::preferredSize(con
 
     Vector2D max;
     for (const auto& child : impl->children) {
-        max.x = std::max(childSize(child).x, max.x);
-        max.y += childSize(child).y + m_impl->data.gap;
+        const auto CSIZE = childSize(child);
+        max.x            = std::max(CSIZE.x, max.x);
+        max.y += CSIZE.y + m_impl->data.gap;
     }
 
     if (!impl->children.empty())

--- a/src/element/rowLayout/RowLayout.cpp
+++ b/src/element/rowLayout/RowLayout.cpp
@@ -39,10 +39,10 @@ void CRowLayoutElement::reposition(const Hyprutils::Math::CBox& sbox, const Hypr
 }
 
 Hyprutils::Math::Vector2D CRowLayoutElement::childSize(Hyprutils::Memory::CSharedPointer<IElement> child) {
-    if (child->preferredSize(impl->position.size()))
-        return *child->preferredSize(impl->position.size());
-    else if (child->minimumSize(impl->position.size()))
-        return *child->minimumSize(impl->position.size());
+    if (const auto PREFERRED = child->preferredSize(impl->position.size()); PREFERRED)
+        return *PREFERRED;
+    if (const auto MINIMUM = child->minimumSize(impl->position.size()); MINIMUM)
+        return *MINIMUM;
     return {-1, -1};
 }
 
@@ -58,8 +58,9 @@ std::optional<Hyprutils::Math::Vector2D> CRowLayoutElement::preferredSize(const 
 
     Vector2D max;
     for (const auto& child : impl->children) {
-        max.x += childSize(child).x + m_impl->data.gap;
-        max.y = std::max(max.y, childSize(child).y);
+        const auto CSIZE = childSize(child);
+        max.x += CSIZE.x + m_impl->data.gap;
+        max.y = std::max(max.y, CSIZE.y);
     }
 
     if (!impl->children.empty())


### PR DESCRIPTION
Row and column layouts measure every child twice, in two places:

- `childSize()` calls `preferredSize()` once to test the optional, then again to deref it (same for `minimumSize`).
- `preferredSize()` calls `childSize()` twice per child — once for `.x`, once for `.y`.

2 × 2 = **4× per nesting level**. `preferredSize()` recurses the whole subtree uncached, so one pass is `O(N · 4^depth)`.

Patch stores each result in a local and reuses it. 14 insertions, 12 deletions.

### Cost per layout pass

20 elements, depth varied, Release `-O3`:

| depth | before | after |
|---|---|---|
| 4 | 0.052 ms | 0.004 ms |
| 6 | 0.700 ms | 0.006 ms |
| 8 | 7.81 ms | 0.008 ms |
| 10 | 104.3 ms | 0.011 ms |

Before grows ~3.2–3.9× per level; after is flat.

Real case that led here — a settings page, 290 elements ~11 levels deep: **5029 ms → 0.19 ms**. `preferredSize()` calls on one pass: 899,224,717 → 10,267.

At depth 10 this is enough to make scrolling take seconds; the page was unusable and the element count (290) looked far too small to blame.

### Verification

- `tests/`: 37/37 pass on both stock and patched.
- Element positions and sizes dumped for every node and diffed stock vs patched across 4 tree shapes (173 elements, mixed AUTO/ABSOLUTE/PERCENT + text): byte-identical.

Not addressed here: `LinearLayout::reposition` also recomputes in its placement loop what it measured in its sizing loop. Separate, non-exponential; happy to follow up.