### PR TITLE
core: add an embedded backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ target_include_directories(
   PUBLIC "./include"
   PRIVATE "./src" "./src/include" "./protocols" "${CMAKE_BINARY_DIR}")
 set_target_properties(hyprtoolkit PROPERTIES VERSION ${HYPRTOOLKIT_VERSION}
-                                             SOVERSION 5)
+                                              SOVERSION 5)
 target_link_libraries(hyprtoolkit PUBLIC OpenGL::EGL OpenGL::OpenGL
                                          PkgConfig::deps)
 
@@ -213,6 +213,10 @@ if(BUILD_TESTING)
                                      OpenGL::OpenGL PkgConfig::deps)
 
   gtest_discover_tests(hyprtoolkit_tests)
+
+  add_executable(embeddedRendererTest "tests/EmbeddedRenderer.cpp")
+  target_link_libraries(embeddedRendererTest PRIVATE hyprtoolkit GTest::gtest_main OpenGL::EGL OpenGL::OpenGL PkgConfig::deps)
+  gtest_discover_tests(embeddedRendererTest)
 
   # Add coverage to hyprtoolkit
   target_compile_options(hyprtoolkit PRIVATE --coverage)

--- a/include/hyprtoolkit/core/Backend.hpp
+++ b/include/hyprtoolkit/core/Backend.hpp
@@ -11,6 +11,7 @@
 #include <sys/poll.h>
 
 #include "LogTypes.hpp"
+#include "BackendServices.hpp"
 #include "SessionLock.hpp"
 #include "../palette/Palette.hpp"
 
@@ -67,9 +68,8 @@ namespace Hyprtoolkit {
             Add a timer func. This will return a pointer, but the pointer doesn't need
             to be kept.
         */
-        virtual Hyprutils::Memory::CAtomicSharedPointer<CTimer> addTimer(const std::chrono::system_clock::duration&                                            timeout,
-                                                                         std::function<void(Hyprutils::Memory::CAtomicSharedPointer<CTimer> self, void* data)> cb_, void* data,
-                                                                         bool force = false) = 0;
+        virtual Hyprutils::Memory::CAtomicSharedPointer<CTimer>
+        addTimer(const TimerDuration& timeout, std::function<void(Hyprutils::Memory::CAtomicSharedPointer<CTimer> self, void* data)> cb_, void* data, bool force = false) = 0;
 
         /*
             Add an idle func. This fn will be executed as soon as possible, but

--- a/include/hyprtoolkit/core/BackendServices.hpp
+++ b/include/hyprtoolkit/core/BackendServices.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <hyprutils/math/Box.hpp>
+#include <hyprutils/memory/Atomic.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <hyprutils/signal/Signal.hpp>
+
+#include "../types/PointerShape.hpp"
+#include "SessionLock.hpp"
+
+namespace Hyprtoolkit {
+    class CTimer;
+    class IOutput;
+
+    using TimerDuration     = std::chrono::steady_clock::duration;
+    using EmbeddedSurfaceID = uint64_t;
+
+    class IEventLoop {
+      public:
+        virtual ~IEventLoop() = default;
+
+        // All callbacks must execute serially on the thread that owns toolkit
+        // surfaces. The host retains callbacks until they run or are removed.
+        virtual void addFd(int fd, std::function<void()>&& callback) = 0;
+        virtual void removeFd(int fd)                                = 0;
+        virtual Hyprutils::Memory::CAtomicSharedPointer<CTimer>
+        addTimer(const TimerDuration& timeout, std::function<void(Hyprutils::Memory::CAtomicSharedPointer<CTimer> self, void* data)> callback, void* data, bool force = false) = 0;
+        virtual void addIdle(const std::function<void()>& callback)                                                                                                            = 0;
+        virtual void cancelPending()                                                                                                                                           = 0;
+
+        // Embedded loops are already running and may implement this as a no-op.
+        virtual void enterLoop() = 0;
+    };
+
+    class IClipboard {
+      public:
+        virtual ~IClipboard() = default;
+
+        virtual void        setText(const std::string& text) = 0;
+        virtual std::string getText()                        = 0;
+    };
+
+    class ITextInput {
+      public:
+        virtual ~ITextInput() = default;
+
+        // surface is zero for native backend windows.
+        virtual void activate(EmbeddedSurfaceID surface, const Hyprutils::Math::CBox& cursorBox, const std::string& surroundingText, size_t cursor) = 0;
+        virtual void deactivate(EmbeddedSurfaceID surface)                                                                                          = 0;
+    };
+
+    class ICursor {
+      public:
+        virtual ~ICursor() = default;
+
+        // surface is zero for native backend windows.
+        virtual void setShape(EmbeddedSurfaceID surface, ePointerShape shape) = 0;
+    };
+
+    class IOutputProvider {
+      public:
+        virtual ~IOutputProvider() = default;
+
+        virtual std::vector<Hyprutils::Memory::CSharedPointer<IOutput>> outputs() = 0;
+
+        struct {
+            Hyprutils::Signal::CSignalT<Hyprutils::Memory::CSharedPointer<IOutput>> outputAdded;
+        } m_events;
+    };
+
+    class ISessionLockProvider {
+      public:
+        virtual ~ISessionLockProvider() = default;
+
+        virtual std::expected<Hyprutils::Memory::CSharedPointer<ISessionLockState>, eSessionLockError> acquire() = 0;
+    };
+}

--- a/include/hyprtoolkit/core/EmbeddedBackend.hpp
+++ b/include/hyprtoolkit/core/EmbeddedBackend.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Backend.hpp"
+#include "BackendServices.hpp"
+
+namespace Hyprtoolkit {
+    class IEmbeddedSurface;
+
+    class IEmbeddedBackend : public IBackend {
+      public:
+        struct SCreationData {
+            SBackendCreationData                                    common;
+
+            Hyprutils::Memory::CSharedPointer<IEventLoop>           eventLoop;
+            Hyprutils::Memory::CSharedPointer<IClipboard>           clipboard;
+            Hyprutils::Memory::CSharedPointer<ITextInput>           textInput;
+            Hyprutils::Memory::CSharedPointer<ICursor>              cursor;
+            Hyprutils::Memory::CSharedPointer<IOutputProvider>      outputs;
+            Hyprutils::Memory::CSharedPointer<ISessionLockProvider> sessionLock;
+        };
+
+        // Creation and destruction require the GLES3 EGL context that will be
+        // used for rendering to be current on the calling thread.
+        static Hyprutils::Memory::CSharedPointer<IEmbeddedBackend> create(const SCreationData& data);
+
+        // Embedded surfaces do not support native popups yet. Popup-backed
+        // controls, including combobox dropdowns and tooltips, remain closed.
+        virtual Hyprutils::Memory::CSharedPointer<IEmbeddedSurface> createSurface() = 0;
+
+      protected:
+        IEmbeddedBackend() = default;
+    };
+}

--- a/include/hyprtoolkit/core/Input.hpp
+++ b/include/hyprtoolkit/core/Input.hpp
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <string>
 
+#include <hyprutils/math/Vector2D.hpp>
+
 namespace Hyprtoolkit::Input {
     enum eMouseButton : uint8_t {
         MOUSE_BUTTON_UNKNOWN,
@@ -35,5 +37,11 @@ namespace Hyprtoolkit::Input {
         bool        repeat    = false;
         std::string utf8      = "";
         uint32_t    modMask   = 0; // eKeyboardModifier
+    };
+
+    struct STouchEvent {
+        int32_t                   id = 0;
+        Hyprutils::Math::Vector2D local;
+        uint32_t                  timeMs = 0;
     };
 }

--- a/include/hyprtoolkit/element/Element.hpp
+++ b/include/hyprtoolkit/element/Element.hpp
@@ -65,6 +65,11 @@ namespace Hyprtoolkit {
         virtual void setMouseMove(std::function<void(const Hyprutils::Math::Vector2D&)>&& fn);
         virtual void setMouseButton(std::function<void(Input::eMouseButton, bool)>&& fn);
         virtual void setMouseAxis(std::function<void(Input::eAxisAxis, float)>&& fn);
+        virtual void setReceivesTouch(bool x);
+        virtual void setTouchDown(std::function<void(const Input::STouchEvent&)>&& fn);
+        virtual void setTouchMotion(std::function<void(const Input::STouchEvent&)>&& fn);
+        virtual void setTouchUp(std::function<void(const Input::STouchEvent&)>&& fn);
+        virtual void setTouchCancel(std::function<void(const Input::STouchEvent&)>&& fn);
 
         virtual void setTooltip(std::string&&);
 
@@ -92,6 +97,7 @@ namespace Hyprtoolkit {
 
         virtual bool                                     acceptsMouseInput();
         virtual bool                                     acceptsKeyboardInput();
+        virtual bool                                     acceptsTouchInput();
         virtual ePointerShape                            pointerShape();
         virtual std::function<ePointerShape()>           pointerShapeFn();
         virtual bool                                     alwaysGetMouseInput();

--- a/include/hyprtoolkit/window/EmbeddedSurface.hpp
+++ b/include/hyprtoolkit/window/EmbeddedSurface.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <hyprutils/math/Region.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <hyprutils/signal/Signal.hpp>
+
+#include "../core/Input.hpp"
+#include "../core/BackendServices.hpp"
+#include "../types/PointerShape.hpp"
+
+namespace Hyprtoolkit {
+    class IElement;
+
+    class IEmbeddedSurface {
+      public:
+        virtual ~IEmbeddedSurface() = default;
+
+        virtual void resize(const Hyprutils::Math::Vector2D& logicalSize, const Hyprutils::Math::Vector2D& pixelSize, float scale) = 0;
+
+        // Every method must be called serially on the toolkit event-loop
+        // thread. The GLES3 context and destination draw framebuffer must be
+        // current for render(). Rendering uses premultiplied alpha and restores
+        // modified GL state. A buffer age of zero requests a full redraw.
+        virtual void render(uint32_t bufferAge = 1) = 0;
+
+        virtual void pointerEnter(const Hyprutils::Math::Vector2D& local)    = 0;
+        virtual void pointerMotion(const Hyprutils::Math::Vector2D& local)   = 0;
+        virtual void pointerButton(Input::eMouseButton button, bool pressed) = 0;
+        virtual void pointerAxis(Input::eAxisAxis axis, float delta)         = 0;
+        virtual void pointerLeave()                                          = 0;
+        virtual void keyboardEnter()                                         = 0;
+        virtual void keyboardKey(const Input::SKeyboardKeyEvent& event)      = 0;
+        virtual void keyboardLeave()                                         = 0;
+        virtual void imCommit(const std::string& text)                       = 0;
+        virtual void imApply()                                               = 0;
+        // A primary touch without a touch-aware target emulates a captured
+        // left-button tap on release. Drag controls should consume touch events.
+        virtual void                                        touchDown(int32_t id, const Hyprutils::Math::Vector2D& local, uint32_t timeMs)   = 0;
+        virtual void                                        touchMotion(int32_t id, const Hyprutils::Math::Vector2D& local, uint32_t timeMs) = 0;
+        virtual void                                        touchUp(int32_t id, uint32_t timeMs)                                             = 0;
+        virtual void                                        touchCancel(int32_t id, uint32_t timeMs)                                         = 0;
+
+        virtual Hyprutils::Memory::CSharedPointer<IElement> rootElement() = 0;
+        virtual EmbeddedSurfaceID                           id()          = 0;
+
+        struct {
+            Hyprutils::Signal::CSignalT<>                         frameRequested;
+            Hyprutils::Signal::CSignalT<Hyprutils::Math::CRegion> damaged;
+            Hyprutils::Signal::CSignalT<ePointerShape>            cursorChanged;
+        } m_events;
+    };
+}

--- a/src/core/Backend.cpp
+++ b/src/core/Backend.cpp
@@ -4,6 +4,7 @@
 #include <hyprtoolkit/palette/Palette.hpp>
 
 #include "InternalBackend.hpp"
+#include "BackendContext.hpp"
 #include "AnimationManager.hpp"
 
 #include "./platforms/WaylandPlatform.hpp"
@@ -37,6 +38,69 @@ using namespace Hyprutils::Memory;
 
 #define SP CSharedPointer
 #define WP CWeakPointer
+
+class CWaylandClipboard final : public IClipboard {
+  public:
+    void setText(const std::string& text) override {
+        g_waylandPlatform->setClipboard(text);
+    }
+
+    std::string getText() override {
+        return g_waylandPlatform->readClipboard();
+    }
+};
+
+class CWaylandTextInput final : public ITextInput {
+  public:
+    void activate(EmbeddedSurfaceID surface, const Hyprutils::Math::CBox& cursorBox, const std::string& surroundingText, size_t cursor) override {
+        if (!g_waylandPlatform->m_waylandState.textInput)
+            return;
+
+        if (!g_waylandPlatform->m_waylandState.imState.enabled) {
+            g_waylandPlatform->m_waylandState.textInput->sendEnable();
+            g_waylandPlatform->m_waylandState.imState.enabled = true;
+        }
+
+        g_waylandPlatform->m_waylandState.textInput->sendSetCursorRectangle(cursorBox.x, cursorBox.y, cursorBox.w, cursorBox.h);
+        g_waylandPlatform->m_waylandState.textInput->sendCommit();
+    }
+
+    void deactivate(EmbeddedSurfaceID surface) override {
+        if (!g_waylandPlatform->m_waylandState.textInput || !g_waylandPlatform->m_waylandState.imState.enabled)
+            return;
+
+        g_waylandPlatform->m_waylandState.textInput->sendDisable();
+        g_waylandPlatform->m_waylandState.imState.enabled = false;
+    }
+};
+
+class CWaylandCursor final : public ICursor {
+  public:
+    void setShape(EmbeddedSurfaceID surface, ePointerShape shape) override {
+        g_waylandPlatform->setCursor(shape);
+    }
+};
+
+class CWaylandOutputProvider final : public IOutputProvider {
+  public:
+    std::vector<SP<IOutput>> outputs() override {
+        return std::vector<SP<IOutput>>(g_waylandPlatform->m_outputs.begin(), g_waylandPlatform->m_outputs.end());
+    }
+};
+
+class CWaylandSessionLockProvider final : public ISessionLockProvider {
+  public:
+    std::expected<SP<ISessionLockState>, eSessionLockError> acquire() override {
+        if (!g_waylandPlatform->m_waylandState.sessionLock)
+            return std::unexpected(LOCK_ERROR_PLATFORM_UNINITIALIZED);
+
+        const auto lockState = g_waylandPlatform->aquireSessionLock();
+        if (!lockState || lockState->m_denied)
+            return std::unexpected(LOCK_ERROR_DENIED);
+
+        return lockState;
+    }
+};
 
 CBackend::CBackend() {
     pipe(m_sLoopState.exitfd);
@@ -89,25 +153,48 @@ SP<IBackend> IBackend::create() {
     if (!g_logger)
         g_logger = makeShared<CLogger>();
 
-    g_backend = SP<CBackend>(new CBackend());
-    auto bk   = g_backend;
-    g_config  = makeShared<CConfigManager>();
+    auto backend     = SP<CBackend>(new CBackend());
+    g_backend        = backend;
+    g_waylandBackend = backend;
+    auto bk          = g_backend;
+
+    g_backendServices             = makeUnique<SBackendServices>(makeDefaultBackendServices());
+    g_backendServices->eventLoop  = dynamicPointerCast<IEventLoop>(backend);
+    g_backendServices->openWindow = [weak = WP<CBackend>{backend}](const SWindowCreationData& data) -> SP<IWindow> {
+        if (const auto locked = weak.lock())
+            return locked->openWindow(data);
+        return nullptr;
+    };
+    g_backendServices->doOnReadable = [weak = WP<CBackend>{backend}](Hyprutils::OS::CFileDescriptor fd, std::function<void()>&& callback) {
+        if (const auto locked = weak.lock())
+            locked->doOnReadable(std::move(fd), std::move(callback));
+    };
+    g_config = makeShared<CConfigManager>();
     g_config->parse();
     g_palette     = CPalette::palette();
     g_iconFactory = SP<CSystemIconFactory>(new CSystemIconFactory());
-    if (!g_backend->m_aqBackend || !g_backend->m_aqBackend->start()) {
+    if (!backend->m_aqBackend || !backend->m_aqBackend->start()) {
         g_logger->log(HT_LOG_ERROR, "couldn't start aq backend");
+        g_backendServices.reset();
+        g_waylandBackend.reset();
         g_backend.reset();
         return nullptr;
     }
     g_waylandPlatform = makeUnique<CWaylandPlatform>();
     if (!g_waylandPlatform->attempt()) {
         g_waylandPlatform = nullptr;
+        g_backendServices.reset();
+        g_waylandBackend.reset();
         g_backend.reset();
         return nullptr;
     }
-    g_openGL   = makeShared<COpenGLRenderer>(g_waylandPlatform->m_drmState.fd);
-    g_renderer = g_openGL;
+    g_backendServices->clipboard   = makeShared<CWaylandClipboard>();
+    g_backendServices->textInput   = makeShared<CWaylandTextInput>();
+    g_backendServices->cursor      = makeShared<CWaylandCursor>();
+    g_backendServices->outputs     = makeShared<CWaylandOutputProvider>();
+    g_backendServices->sessionLock = makeShared<CWaylandSessionLockProvider>();
+    g_openGL                       = makeShared<COpenGLRenderer>(g_waylandPlatform->m_drmState.fd);
+    g_renderer                     = g_openGL;
 
     // run cleanup while every inline static SP is still alive. by the time
     // ~CBackend reaches static destruction, sibling globals like g_renderer
@@ -135,21 +222,15 @@ SP<CPalette> CBackend::getPalette() {
 }
 
 std::vector<SP<IOutput>> CBackend::getOutputs() {
-    if (!g_waylandPlatform)
+    if (!g_backendServices)
         return {};
-
-    return std::vector<SP<IOutput>>(g_waylandPlatform->m_outputs.begin(), g_waylandPlatform->m_outputs.end());
+    return g_backendServices->outputs->outputs();
 }
 
 std::expected<SP<ISessionLockState>, eSessionLockError> CBackend::aquireSessionLock() {
-    if (!g_waylandPlatform)
+    if (!g_backendServices)
         return std::unexpected(LOCK_ERROR_PLATFORM_UNINITIALIZED);
-
-    auto lockState = g_waylandPlatform->aquireSessionLock();
-    if (!lockState || lockState->m_denied)
-        return std::unexpected(LOCK_ERROR_DENIED);
-
-    return lockState;
+    return g_backendServices->sessionLock->acquire();
 }
 
 SP<IWindow> CBackend::openWindow(const SWindowCreationData& data) {
@@ -188,7 +269,7 @@ SP<IWindow> CBackend::openWindow(const SWindowCreationData& data) {
     return w;
 }
 
-ASP<CTimer> CBackend::addTimer(const std::chrono::system_clock::duration& timeout, std::function<void(ASP<CTimer> self, void* data)> cb_, void* data, bool force) {
+ASP<CTimer> CBackend::addTimer(const TimerDuration& timeout, std::function<void(ASP<CTimer> self, void* data)> cb_, void* data, bool force) {
     std::lock_guard<std::mutex> lg(m_sLoopState.timersMutex);
     const auto                  T = m_timers.emplace_back(makeAtomicShared<CTimer>(timeout, cb_, data, force));
     m_sLoopState.timerEvent       = true;
@@ -201,6 +282,19 @@ void CBackend::addIdle(const std::function<void()>& fn) {
     m_idles.emplace_back(makeAtomicShared<std::function<void()>>(fn));
     m_sLoopState.idleEvent = true;
     m_sLoopState.idleCV.notify_all();
+}
+
+void CBackend::cancelPending() {
+    {
+        std::lock_guard<std::mutex> lock(m_sLoopState.timersMutex);
+        m_timers.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_sLoopState.idlesMutex);
+        m_idles.clear();
+    }
+    m_sLoopState.userFds.clear();
+    rebuildPollfds();
 }
 
 void CBackend::terminate() {
@@ -220,6 +314,8 @@ void CBackend::terminate() {
         g_renderer.reset();
         g_openGL.reset();
 
+        g_backendServices.reset();
+        g_waylandBackend.reset();
         g_waylandPlatform.reset();
 
         g_asyncResourceGatherer.reset();
@@ -538,6 +634,8 @@ void CBackend::enterLoop() {
     g_renderer.reset();
     g_openGL.reset();
 
+    g_backendServices.reset();
+    g_waylandBackend.reset();
     g_waylandPlatform.reset();
 
     g_asyncResourceGatherer.reset();

--- a/src/core/Backend.hpp
+++ b/src/core/Backend.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <hyprtoolkit/core/Backend.hpp>
+#include <hyprtoolkit/core/BackendServices.hpp>
 #include <hyprutils/os/FileDescriptor.hpp>
 #include <hyprutils/cli/Logger.hpp>
 #include <hyprgraphics/resource/AsyncResourceGatherer.hpp>
@@ -14,21 +15,22 @@ namespace Hyprtoolkit {
     class CConfigManager;
     class CSystemIconFactory;
 
-    class CBackend : public IBackend {
+    class CBackend : public IBackend, public IEventLoop {
       public:
         CBackend();
         virtual ~CBackend();
 
-        virtual void                   destroy();
-        virtual void                   setLogFn(LogFn&& fn);
-        virtual void                   addFd(int fd, std::function<void()>&& callback);
-        virtual void                   removeFd(int fd);
-        virtual SP<ISystemIconFactory> systemIcons();
-        virtual ASP<CTimer> addTimer(const std::chrono::system_clock::duration& timeout, std::function<void(ASP<CTimer> self, void* data)> cb_, void* data, bool force = false);
-        virtual void        addIdle(const std::function<void()>& fn);
-        virtual void        enterLoop();
-        virtual std::vector<SP<IOutput>>                                getOutputs();
-        virtual SP<CPalette>                                            getPalette();
+        virtual void                     destroy();
+        virtual void                     setLogFn(LogFn&& fn);
+        virtual void                     addFd(int fd, std::function<void()>&& callback);
+        virtual void                     removeFd(int fd);
+        virtual SP<ISystemIconFactory>   systemIcons();
+        virtual ASP<CTimer>              addTimer(const TimerDuration& timeout, std::function<void(ASP<CTimer> self, void* data)> cb_, void* data, bool force = false);
+        virtual void                     addIdle(const std::function<void()>& fn);
+        virtual void                     cancelPending();
+        virtual void                     enterLoop();
+        virtual std::vector<SP<IOutput>> getOutputs();
+        virtual SP<CPalette>             getPalette();
         virtual std::expected<SP<ISessionLockState>, eSessionLockError> aquireSessionLock();
 
         // ======================= Internal fns ======================= //

--- a/src/core/BackendContext.cpp
+++ b/src/core/BackendContext.cpp
@@ -1,0 +1,68 @@
+#include "BackendContext.hpp"
+
+#include <hyprtoolkit/core/Output.hpp>
+
+#include <atomic>
+
+using namespace Hyprtoolkit;
+
+SBackendLifetime::SBackendLifetime() :
+    generation([] {
+        static std::atomic<uint64_t> next = 1;
+        return next.fetch_add(1, std::memory_order_relaxed);
+    }()) {
+    ;
+}
+
+class CNullClipboard final : public IClipboard {
+  public:
+    void setText(const std::string& text) override {
+        ;
+    }
+
+    std::string getText() override {
+        return {};
+    }
+};
+
+class CNullTextInput final : public ITextInput {
+  public:
+    void activate(EmbeddedSurfaceID surface, const Hyprutils::Math::CBox& cursorBox, const std::string& surroundingText, size_t cursor) override {
+        ;
+    }
+
+    void deactivate(EmbeddedSurfaceID surface) override {
+        ;
+    }
+};
+
+class CNullCursor final : public ICursor {
+  public:
+    void setShape(EmbeddedSurfaceID surface, ePointerShape shape) override {
+        ;
+    }
+};
+
+class CEmptyOutputProvider final : public IOutputProvider {
+  public:
+    std::vector<SP<IOutput>> outputs() override {
+        return {};
+    }
+};
+
+class CUnsupportedSessionLockProvider final : public ISessionLockProvider {
+  public:
+    std::expected<SP<ISessionLockState>, eSessionLockError> acquire() override {
+        return std::unexpected(LOCK_ERROR_PLATFORM_UNINITIALIZED);
+    }
+};
+
+SBackendServices Hyprtoolkit::makeDefaultBackendServices() {
+    return SBackendServices{
+        .clipboard   = makeShared<CNullClipboard>(),
+        .textInput   = makeShared<CNullTextInput>(),
+        .cursor      = makeShared<CNullCursor>(),
+        .outputs     = makeShared<CEmptyOutputProvider>(),
+        .sessionLock = makeShared<CUnsupportedSessionLockProvider>(),
+    };
+}

--- a/src/core/BackendContext.hpp
+++ b/src/core/BackendContext.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <functional>
+
+#include <hyprutils/os/FileDescriptor.hpp>
+
+#include <hyprtoolkit/core/BackendServices.hpp>
+
+#include "../helpers/Memory.hpp"
+
+namespace Hyprtoolkit {
+    class IWindow;
+    struct SWindowCreationData;
+
+    struct SBackendLifetime {
+        SBackendLifetime();
+
+        const uint64_t generation;
+    };
+
+    struct SBackendServices {
+        SP<SBackendLifetime>                                                         lifetime = makeShared<SBackendLifetime>();
+        SP<IEventLoop>                                                               eventLoop;
+        SP<IClipboard>                                                               clipboard;
+        SP<ITextInput>                                                               textInput;
+        SP<ICursor>                                                                  cursor;
+        SP<IOutputProvider>                                                          outputs;
+        SP<ISessionLockProvider>                                                     sessionLock;
+
+        std::function<SP<IWindow>(const SWindowCreationData&)>                       openWindow;
+        std::function<void(Hyprutils::OS::CFileDescriptor, std::function<void()>&&)> doOnReadable;
+    };
+
+    SBackendServices            makeDefaultBackendServices();
+
+    inline UP<SBackendServices> g_backendServices;
+}

--- a/src/core/EmbeddedBackend.cpp
+++ b/src/core/EmbeddedBackend.cpp
@@ -1,0 +1,181 @@
+#include "EmbeddedBackend.hpp"
+
+#include "AnimationManager.hpp"
+#include "BackendContext.hpp"
+#include "InternalBackend.hpp"
+#include "Logger.hpp"
+#include "../palette/ConfigManager.hpp"
+#include "../renderer/gl/OpenGL.hpp"
+#include "../system/Icons.hpp"
+#include "../window/EmbeddedSurface.hpp"
+
+using namespace Hyprtoolkit;
+
+SP<IEmbeddedBackend> IEmbeddedBackend::create(const SCreationData& data) {
+    if (g_backend || !data.eventLoop)
+        return nullptr;
+
+    g_logger                     = makeShared<CLogger>();
+    g_logger->m_loggerConnection = data.common.pLogConnection;
+    g_logger->updateLogLevel();
+
+    auto backend = makeShared<CEmbeddedBackend>(data);
+    g_backend    = backend;
+
+    backend->m_outputAddedListener = g_backendServices->outputs->m_events.outputAdded.listen([weak = WP<CEmbeddedBackend>{backend}](SP<IOutput> output) {
+        if (const auto locked = weak.lock())
+            if (!locked->m_destroyed)
+                locked->m_events.outputAdded.emit(output);
+    });
+
+    g_config = makeShared<CConfigManager>();
+    g_config->parse();
+    g_palette               = CPalette::palette();
+    g_iconFactory           = SP<CSystemIconFactory>(new CSystemIconFactory());
+    g_asyncResourceGatherer = makeShared<Hyprgraphics::CAsyncResourceGatherer>();
+    g_animationManager      = makeShared<CHTAnimationManager>();
+    g_openGL                = makeShared<COpenGLRenderer>();
+    g_renderer              = g_openGL;
+
+    return backend;
+}
+
+CEmbeddedBackend::CEmbeddedBackend(const SCreationData& data) {
+    g_backendServices              = makeUnique<SBackendServices>(makeDefaultBackendServices());
+    g_backendServices->eventLoop   = data.eventLoop;
+    g_backendServices->clipboard   = data.clipboard ? data.clipboard : g_backendServices->clipboard;
+    g_backendServices->textInput   = data.textInput ? data.textInput : g_backendServices->textInput;
+    g_backendServices->cursor      = data.cursor ? data.cursor : g_backendServices->cursor;
+    g_backendServices->outputs     = data.outputs ? data.outputs : g_backendServices->outputs;
+    g_backendServices->sessionLock = data.sessionLock ? data.sessionLock : g_backendServices->sessionLock;
+}
+
+CEmbeddedBackend::~CEmbeddedBackend() {
+    destroy();
+}
+
+void CEmbeddedBackend::destroy() {
+    if (m_destroyed || m_destroyRequested)
+        return;
+
+    if (m_activeFrames > 0) {
+        m_destroyRequested = true;
+        return;
+    }
+
+    destroyNow();
+}
+
+void CEmbeddedBackend::destroyNow() {
+    if (m_destroyed)
+        return;
+
+    const auto keepAlive = g_backend;
+    (void)keepAlive;
+    m_destroyed        = true;
+    m_destroyRequested = false;
+
+    g_backendServices->eventLoop->cancelPending();
+    m_outputAddedListener.reset();
+
+    for (const auto& surface : m_surfaces) {
+        if (surface)
+            surface->invalidate();
+    }
+    m_surfaces.clear();
+
+    g_asyncResourceGatherer.reset();
+    g_animationManager.reset();
+    g_iconFactory.reset();
+    g_config.reset();
+    g_palette.reset();
+
+    g_renderer.reset();
+    g_openGL.reset();
+
+    g_backendServices.reset();
+    g_logger.reset();
+    g_backend.reset();
+}
+
+void CEmbeddedBackend::setLogFn(LogFn&& fn) {
+    if (m_destroyed || !g_logger)
+        return;
+    g_logger->m_logFn = std::move(fn);
+}
+
+void CEmbeddedBackend::addFd(int fd, std::function<void()>&& callback) {
+    if (m_destroyed)
+        return;
+    g_backendServices->eventLoop->addFd(fd, std::move(callback));
+}
+
+void CEmbeddedBackend::removeFd(int fd) {
+    if (m_destroyed)
+        return;
+    g_backendServices->eventLoop->removeFd(fd);
+}
+
+SP<ISystemIconFactory> CEmbeddedBackend::systemIcons() {
+    return g_iconFactory;
+}
+
+ASP<CTimer> CEmbeddedBackend::addTimer(const TimerDuration& timeout, std::function<void(ASP<CTimer> self, void* data)> callback, void* data, bool force) {
+    if (m_destroyed)
+        return nullptr;
+    return g_backendServices->eventLoop->addTimer(timeout, std::move(callback), data, force);
+}
+
+void CEmbeddedBackend::enterLoop() {
+    if (m_destroyed)
+        return;
+    g_backendServices->eventLoop->enterLoop();
+}
+
+void CEmbeddedBackend::addIdle(const std::function<void()>& callback) {
+    if (m_destroyed)
+        return;
+    g_backendServices->eventLoop->addIdle(callback);
+}
+
+SP<CPalette> CEmbeddedBackend::getPalette() {
+    return g_palette;
+}
+
+std::vector<SP<IOutput>> CEmbeddedBackend::getOutputs() {
+    if (m_destroyed)
+        return {};
+    return g_backendServices->outputs->outputs();
+}
+
+std::expected<SP<ISessionLockState>, eSessionLockError> CEmbeddedBackend::aquireSessionLock() {
+    if (m_destroyed)
+        return std::unexpected(LOCK_ERROR_PLATFORM_UNINITIALIZED);
+    return g_backendServices->sessionLock->acquire();
+}
+
+SP<IEmbeddedSurface> CEmbeddedBackend::createSurface() {
+    if (m_destroyed || m_destroyRequested)
+        return nullptr;
+
+    auto surface = makeShared<CEmbeddedSurface>();
+    surface->setSelf(surface, dynamicPointerCast<CEmbeddedBackend>(g_backend));
+    surface->open();
+    m_surfaces.emplace_back(surface);
+    return dynamicPointerCast<IEmbeddedSurface>(surface);
+}
+
+bool CEmbeddedBackend::beginFrame() {
+    if (m_destroyed || m_destroyRequested)
+        return false;
+    m_activeFrames++;
+    return true;
+}
+
+void CEmbeddedBackend::endFrame() {
+    if (m_activeFrames == 0)
+        return;
+    m_activeFrames--;
+    if (m_activeFrames == 0 && m_destroyRequested)
+        destroyNow();
+}

--- a/src/core/EmbeddedBackend.hpp
+++ b/src/core/EmbeddedBackend.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <hyprtoolkit/core/EmbeddedBackend.hpp>
+#include <hyprutils/signal/Listener.hpp>
+
+#include "../helpers/Memory.hpp"
+
+namespace Hyprtoolkit {
+    class CEmbeddedSurface;
+
+    class CEmbeddedBackend final : public IEmbeddedBackend {
+      public:
+        explicit CEmbeddedBackend(const SCreationData& data);
+        ~CEmbeddedBackend();
+
+        void                     destroy() override;
+        void                     setLogFn(LogFn&& fn) override;
+        void                     addFd(int fd, std::function<void()>&& callback) override;
+        void                     removeFd(int fd) override;
+        SP<ISystemIconFactory>   systemIcons() override;
+        ASP<CTimer>              addTimer(const TimerDuration& timeout, std::function<void(ASP<CTimer> self, void* data)> callback, void* data, bool force = false) override;
+        void                     enterLoop() override;
+        void                     addIdle(const std::function<void()>& callback) override;
+        SP<CPalette>             getPalette() override;
+        std::vector<SP<IOutput>> getOutputs() override;
+        std::expected<SP<ISessionLockState>, eSessionLockError> aquireSessionLock() override;
+
+        SP<IEmbeddedSurface>                                    createSurface() override;
+
+        bool                                                    beginFrame();
+        void                                                    endFrame();
+
+      private:
+        void                                   destroyNow();
+
+        bool                                   m_destroyed        = false;
+        bool                                   m_destroyRequested = false;
+        size_t                                 m_activeFrames     = 0;
+        std::vector<WP<CEmbeddedSurface>>      m_surfaces;
+        Hyprutils::Signal::CHyprSignalListener m_outputAddedListener;
+
+        friend class IEmbeddedBackend;
+    };
+}

--- a/src/core/InternalBackend.hpp
+++ b/src/core/InternalBackend.hpp
@@ -10,11 +10,14 @@
 
 namespace Hyprtoolkit {
 
+    class IBackend;
+    class CBackend;
     class CPalette;
     class CConfigManager;
     class CSystemIconFactory;
 
-    inline Hyprutils::Memory::CSharedPointer<Hyprtoolkit::CBackend>                g_backend;
+    inline Hyprutils::Memory::CSharedPointer<IBackend>                             g_backend;
+    inline Hyprutils::Memory::CWeakPointer<CBackend>                               g_waylandBackend;
     inline Hyprutils::Memory::CSharedPointer<Hyprgraphics::CAsyncResourceGatherer> g_asyncResourceGatherer;
     inline Hyprutils::Memory::CSharedPointer<CPalette>                             g_palette;
     inline Hyprutils::Memory::CSharedPointer<CConfigManager>                       g_config;

--- a/src/core/platforms/WaylandPlatform.cpp
+++ b/src/core/platforms/WaylandPlatform.cpp
@@ -634,9 +634,9 @@ bool CWaylandPlatform::initDmabuf() {
         g_logger->log(HT_LOG_DEBUG, "zwp_linux_dmabuf_v1: opened node {} with fd {}", m_drmState.nodeName, m_drmState.fd);
     }
 
-    m_allocator = Aquamarine::CGBMAllocator::create(m_drmState.fd, g_backend->m_aqBackend);
+    m_allocator = Aquamarine::CGBMAllocator::create(m_drmState.fd, g_waylandBackend->m_aqBackend);
 
-    auto nullBackend = reinterpretPointerCast<Aquamarine::CNullBackend>(g_backend->m_aqBackend->getImplementations().at(0));
+    auto nullBackend = reinterpretPointerCast<Aquamarine::CNullBackend>(g_waylandBackend->m_aqBackend->getImplementations().at(0));
 
     nullBackend->setFormats(m_dmabufFormats);
 

--- a/src/element/Element.cpp
+++ b/src/element/Element.cpp
@@ -51,6 +51,22 @@ IElement::IElement() {
         if (impl->userFns.mouseAxis)
             impl->userFns.mouseAxis(axis, down);
     });
+    impl->m_externalEvents.touchDown.listenStatic([this](Input::STouchEvent event) {
+        if (impl->userFns.touchDown)
+            impl->userFns.touchDown(event);
+    });
+    impl->m_externalEvents.touchMotion.listenStatic([this](Input::STouchEvent event) {
+        if (impl->userFns.touchMotion)
+            impl->userFns.touchMotion(event);
+    });
+    impl->m_externalEvents.touchUp.listenStatic([this](Input::STouchEvent event) {
+        if (impl->userFns.touchUp)
+            impl->userFns.touchUp(event);
+    });
+    impl->m_externalEvents.touchCancel.listenStatic([this](Input::STouchEvent event) {
+        if (impl->userFns.touchCancel)
+            impl->userFns.touchCancel(event);
+    });
 }
 
 IElement::~IElement() {
@@ -260,6 +276,10 @@ bool IElement::acceptsKeyboardInput() {
     return false;
 }
 
+bool IElement::acceptsTouchInput() {
+    return impl->userRequestedTouchInput;
+}
+
 void IElement::imCommitNewText(const std::string& text) {
     ;
 }
@@ -290,6 +310,26 @@ void IElement::setMouseButton(std::function<void(Input::eMouseButton, bool)>&& f
 
 void IElement::setMouseAxis(std::function<void(Input::eAxisAxis, float)>&& fn) {
     impl->userFns.mouseAxis = std::move(fn);
+}
+
+void IElement::setReceivesTouch(bool x) {
+    impl->userRequestedTouchInput = x;
+}
+
+void IElement::setTouchDown(std::function<void(const Input::STouchEvent&)>&& fn) {
+    impl->userFns.touchDown = std::move(fn);
+}
+
+void IElement::setTouchMotion(std::function<void(const Input::STouchEvent&)>&& fn) {
+    impl->userFns.touchMotion = std::move(fn);
+}
+
+void IElement::setTouchUp(std::function<void(const Input::STouchEvent&)>&& fn) {
+    impl->userFns.touchUp = std::move(fn);
+}
+
+void IElement::setTouchCancel(std::function<void(const Input::STouchEvent&)>&& fn) {
+    impl->userFns.touchCancel = std::move(fn);
 }
 
 void IElement::setRepositioned(std::function<void()>&& fn) {

--- a/src/element/Element.hpp
+++ b/src/element/Element.hpp
@@ -34,6 +34,7 @@ namespace Hyprtoolkit {
         bool                                                     growH                   = false;
         float                                                    margin                  = 0;
         bool                                                     userRequestedMouseInput = false;
+        bool                                                     userRequestedTouchInput = false;
         bool                                                     grouped                 = false;
         bool                                                     hasBeenPresented        = false;
 
@@ -64,6 +65,10 @@ namespace Hyprtoolkit {
             Hyprutils::Signal::CSignalT<>                          mouseLeave;
             Hyprutils::Signal::CSignalT<Input::eAxisAxis, float>   mouseAxis;
             Hyprutils::Signal::CSignalT<Input::SKeyboardKeyEvent>  key;
+            Hyprutils::Signal::CSignalT<Input::STouchEvent>        touchDown;
+            Hyprutils::Signal::CSignalT<Input::STouchEvent>        touchMotion;
+            Hyprutils::Signal::CSignalT<Input::STouchEvent>        touchUp;
+            Hyprutils::Signal::CSignalT<Input::STouchEvent>        touchCancel;
             Hyprutils::Signal::CSignalT<>                          keyboardEnter;
             Hyprutils::Signal::CSignalT<>                          keyboardLeave;
         } m_externalEvents;
@@ -74,6 +79,10 @@ namespace Hyprtoolkit {
             std::function<void(const Hyprutils::Math::Vector2D&)> mouseMove;
             std::function<void(Input::eMouseButton, bool)>        mouseButton;
             std::function<void(Input::eAxisAxis, float)>          mouseAxis;
+            std::function<void(const Input::STouchEvent&)>        touchDown;
+            std::function<void(const Input::STouchEvent&)>        touchMotion;
+            std::function<void(const Input::STouchEvent&)>        touchUp;
+            std::function<void(const Input::STouchEvent&)>        touchCancel;
             std::function<void()>                                 repositioned;
         } userFns;
 

--- a/src/element/combobox/Combobox.cpp
+++ b/src/element/combobox/Combobox.cpp
@@ -7,6 +7,7 @@
 #include <hyprtoolkit/element/Button.hpp>
 
 #include "../../core/InternalBackend.hpp"
+#include "../../core/BackendContext.hpp"
 #include "../../layout/Positioner.hpp"
 #include "../../renderer/Renderer.hpp"
 #include "../../window/ToolkitWindow.hpp"
@@ -134,6 +135,9 @@ void CComboboxElement::openDropdown() {
         .pos           = impl->position.pos() - Vector2D{50.F, 0.F} + Vector2D{0.F, impl->position.size().y},
     });
 
+    if (!m_impl->dropdown.popup)
+        return;
+
     m_impl->listeners.popupClosed = m_impl->dropdown.popup->m_events.popupClosed.listen([this, self = m_impl->self] {
         if (!self)
             return;
@@ -170,16 +174,16 @@ void CComboboxElement::openDropdown() {
                                                   ->noBg(true)
                                                   ->alignText(HT_FONT_ALIGN_LEFT)
                                                   ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_ABSOLUTE, {1.F, DROPDOWN_BUTTON_HEIGHT}})
-                                                  ->onMainClick([i, this, self = m_impl->self](SP<CButtonElement> e) {
-                                                      if (!self)
+                                                  ->onMainClick([i, this, self = m_impl->self, lifetime = WP<SBackendLifetime>{g_backendServices->lifetime}](SP<CButtonElement> e) {
+                                                      if (!self || !lifetime)
                                                           return;
 
                                                       setSelection(i);
                                                       if (m_impl->data.onChanged)
                                                           m_impl->data.onChanged(m_impl->self.lock(), i);
 
-                                                      g_backend->addIdle([this, self = m_impl->self] {
-                                                          if (!self)
+                                                      g_backend->addIdle([this, self = m_impl->self, lifetime] {
+                                                          if (!self || !lifetime)
                                                               return;
 
                                                           closeDropdown();

--- a/src/element/image/Image.cpp
+++ b/src/element/image/Image.cpp
@@ -3,6 +3,7 @@
 #include "../../layout/Positioner.hpp"
 #include "../../renderer/Renderer.hpp"
 #include "../../core/InternalBackend.hpp"
+#include "../../core/BackendContext.hpp"
 #include "../../window/ToolkitWindow.hpp"
 #include "../../system/Icons.hpp"
 #include "../../resource/assetCache/AssetCache.hpp"
@@ -108,12 +109,12 @@ void CImageElement::renderTex() {
 
     if (!m_impl->data.sync) {
         // attach listener before enqueueing to avoid missing the finished event
-        m_impl->resource->m_events.finished.listenStatic([this, self = impl->self] {
-            if (!self)
+        m_impl->resource->m_events.finished.listenStatic([this, self = impl->self, lifetime = WP<SBackendLifetime>{g_backendServices->lifetime}] {
+            if (!self || !lifetime)
                 return;
 
-            g_backend->addIdle([this, self = self]() {
-                if (!self)
+            g_backend->addIdle([this, self = self, lifetime] {
+                if (!self || !lifetime)
                     return;
 
                 m_impl->postImageLoad();

--- a/src/element/text/Text.cpp
+++ b/src/element/text/Text.cpp
@@ -9,6 +9,7 @@
 #include "../../layout/Positioner.hpp"
 #include "../../renderer/Renderer.hpp"
 #include "../../core/InternalBackend.hpp"
+#include "../../core/BackendContext.hpp"
 #include "../../core/Logger.hpp"
 #include "../../core/AnimationManager.hpp"
 #include "../../helpers/Memory.hpp"
@@ -443,14 +444,14 @@ void STextImpl::renderTex() {
         g_asyncResourceGatherer->await(resourceGeneric);
         postTexLoad();
     } else {
-        resource->m_events.finished.listenStatic([this, self = self->impl->self] {
-            if (self.expired())
+        resource->m_events.finished.listenStatic([this, self = self->impl->self, lifetime = WP<SBackendLifetime>{g_backendServices->lifetime}] {
+            if (self.expired() || !lifetime)
                 return;
             if (!g_backend)
                 return;
 
-            g_backend->addIdle([this, self = self]() {
-                if (self.expired())
+            g_backend->addIdle([this, self = self, lifetime] {
+                if (self.expired() || !lifetime)
                     return;
 
                 postTexLoad();

--- a/src/element/textbox/Textbox.cpp
+++ b/src/element/textbox/Textbox.cpp
@@ -10,7 +10,7 @@
 #include "../../renderer/Renderer.hpp"
 #include "../../window/ToolkitWindow.hpp"
 #include "../../core/InternalBackend.hpp"
-#include "../../core/platforms/WaylandPlatform.hpp"
+#include "../../core/BackendContext.hpp"
 #include "../Element.hpp"
 #include "../text/Text.hpp"
 #include "../../helpers/UTF8.hpp"
@@ -354,19 +354,19 @@ void CTextboxElement::init() {
         }
 
         if ((ev.xkbKeysym == XKB_KEY_C || ev.xkbKeysym == XKB_KEY_c) && (ev.modMask & Input::HT_MODIFIER_CTRL)) {
-            if (m_impl->hasSelect() && g_waylandPlatform) {
+            if (m_impl->hasSelect() && g_backendServices && g_backendServices->clipboard) {
                 const auto begin = std::min(m_impl->inputState.selectBegin, m_impl->inputState.selectEnd);
                 const auto end   = std::max(m_impl->inputState.selectBegin, m_impl->inputState.selectEnd);
-                g_waylandPlatform->setClipboard(m_impl->data.text.substr(begin, end - begin));
+                g_backendServices->clipboard->setText(m_impl->data.text.substr(begin, end - begin));
             }
             return;
         }
 
         if ((ev.xkbKeysym == XKB_KEY_X || ev.xkbKeysym == XKB_KEY_x) && (ev.modMask & Input::HT_MODIFIER_CTRL)) {
-            if (m_impl->hasSelect() && g_waylandPlatform) {
+            if (m_impl->hasSelect() && g_backendServices && g_backendServices->clipboard) {
                 const auto begin = std::min(m_impl->inputState.selectBegin, m_impl->inputState.selectEnd);
                 const auto end   = std::max(m_impl->inputState.selectBegin, m_impl->inputState.selectEnd);
-                g_waylandPlatform->setClipboard(m_impl->data.text.substr(begin, end - begin));
+                g_backendServices->clipboard->setText(m_impl->data.text.substr(begin, end - begin));
                 m_impl->removeSelectedText();
                 m_impl->updateLabel();
             }
@@ -374,9 +374,9 @@ void CTextboxElement::init() {
         }
 
         if ((ev.xkbKeysym == XKB_KEY_V || ev.xkbKeysym == XKB_KEY_v) && (ev.modMask & Input::HT_MODIFIER_CTRL)) {
-            if (!g_waylandPlatform)
+            if (!g_backendServices || !g_backendServices->clipboard)
                 return;
-            const auto pasted = g_waylandPlatform->readClipboard();
+            const auto pasted = g_backendServices->clipboard->getText();
             if (pasted.empty())
                 return;
 

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -66,6 +66,7 @@ namespace Hyprtoolkit {
         };
 
         virtual void                 beginRendering(SP<IToolkitWindow> window, SP<Aquamarine::IBuffer> buf) = 0;
+        virtual void                 beginRenderingExternal(SP<IToolkitWindow> window, uint32_t bufferAge)  = 0;
         virtual void                 render(bool ignoreSync = false)                                        = 0;
         virtual void                 endRendering()                                                         = 0;
         virtual void                 renderRectangle(const SRectangleRenderData& data)                      = 0;

--- a/src/renderer/gl/Framebuffer.cpp
+++ b/src/renderer/gl/Framebuffer.cpp
@@ -29,6 +29,8 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
 
     if (!m_tex) {
         m_tex = makeShared<CGLTexture>();
+        if (g_openGL)
+            g_openGL->registerTexture(m_tex);
         m_tex->allocate();
         m_tex->bind();
         glTexParameteri(m_tex->m_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/src/renderer/gl/GLTexture.cpp
+++ b/src/renderer/gl/GLTexture.cpp
@@ -2,30 +2,50 @@
 #include "OpenGL.hpp"
 
 #include "../../core/InternalBackend.hpp"
+#include "../../core/BackendContext.hpp"
 
 using namespace Hyprtoolkit;
+
+CGLTexture::CGLTexture() {
+    if (g_backendServices)
+        m_lifetime = g_backendServices->lifetime;
+}
 
 void CGLTexture::attachAsync(WP<CGLTexture> self, ASP<Hyprgraphics::IAsyncResource> resource) {
     if (resource->m_ready) {
         m_resource = resource;
-        upload();
+        uploadOnContext(self);
         return;
     }
 
-    resource->m_events.finished.listenStatic([self, resource] {
+    resource->m_events.finished.listenStatic([self, resource, lifetime = WP<SBackendLifetime>{g_backendServices->lifetime}] {
         // backend may have been torn down between enqueue and finish (shutdown
         // race). dropping the upload is safe: the texture is either gone too
         // (lock fails below) or about to be.
-        if (!g_backend)
+        if (!g_backend || !lifetime)
             return;
-        g_backend->addIdle([self, resource]() {
+        g_backend->addIdle([self, resource, lifetime] {
             const auto SELF = self.lock();
-            if (!SELF)
+            if (!SELF || !lifetime)
                 return;
             SELF->m_resource = resource;
-            SELF->upload();
+            SELF->uploadOnContext(SELF);
         });
     });
+}
+
+void CGLTexture::uploadOnContext(WP<CGLTexture> self) {
+    if (g_openGL && g_openGL->m_borrowedContext && !g_openGL->m_window) {
+        g_openGL->enqueueGL([self] {
+            if (const auto locked = self.lock())
+                locked->upload();
+        });
+        return;
+    }
+
+    if (g_openGL)
+        g_openGL->makeEGLCurrent();
+    upload();
 }
 
 CGLTexture::~CGLTexture() {
@@ -71,6 +91,20 @@ IRendererTexture::eTextureType CGLTexture::type() {
 }
 
 void CGLTexture::destroy() {
+    if (!m_lifetime) {
+        m_texID     = 0;
+        m_allocated = false;
+        return;
+    }
+
+    if (m_allocated && g_openGL && g_openGL->m_borrowedContext && !g_openGL->contextCurrent()) {
+        const auto texture = m_texID;
+        g_openGL->enqueueGL([texture] { glDeleteTextures(1, &texture); });
+        m_texID     = 0;
+        m_allocated = false;
+        return;
+    }
+
     if (g_openGL)
         g_openGL->makeEGLCurrent();
 
@@ -79,6 +113,14 @@ void CGLTexture::destroy() {
         m_texID = 0;
     }
     m_allocated = false;
+}
+
+void CGLTexture::releaseFromRenderer() {
+    if (m_allocated)
+        glDeleteTextures(1, &m_texID);
+    m_texID     = 0;
+    m_allocated = false;
+    m_type      = TEXTURE_INVALID;
 }
 
 void CGLTexture::allocate() {

--- a/src/renderer/gl/GLTexture.hpp
+++ b/src/renderer/gl/GLTexture.hpp
@@ -11,6 +11,7 @@
 #include "../../helpers/Memory.hpp"
 
 namespace Hyprtoolkit {
+    struct SBackendLifetime;
     enum eGLTextureType : uint8_t {
         TEXTURE_INVALID,  // Invalid
         TEXTURE_RGBA,     // 4 channels
@@ -22,7 +23,7 @@ namespace Hyprtoolkit {
 
     class CGLTexture : public IRendererTexture {
       public:
-        CGLTexture() = default;
+        CGLTexture();
         virtual ~CGLTexture();
 
         virtual size_t                    id();
@@ -45,8 +46,11 @@ namespace Hyprtoolkit {
         Hyprutils::Math::Vector2D         m_size      = {};
 
         ASP<Hyprgraphics::IAsyncResource> m_resource;
+        WP<SBackendLifetime>              m_lifetime;
 
         void                              upload();
+        void                              uploadOnContext(WP<CGLTexture> self);
+        void                              releaseFromRenderer();
         void                              allocate();
         void                              bind();
     };

--- a/src/renderer/gl/OpenGL.cpp
+++ b/src/renderer/gl/OpenGL.cpp
@@ -3,6 +3,7 @@
 #include "../../window/ToolkitWindow.hpp"
 #include "../../Macros.hpp"
 #include "../../core/InternalBackend.hpp"
+#include "../../core/BackendContext.hpp"
 #include "../../element/Element.hpp"
 #include "../sync/SyncTimeline.hpp"
 #include "./shaders/Shaders.hpp"
@@ -330,6 +331,11 @@ EGLDeviceEXT COpenGLRenderer::eglDeviceFromDRMFD(int drmFD) {
 }
 
 void COpenGLRenderer::makeEGLCurrent() {
+    if (m_borrowedContext) {
+        RASSERT(eglGetCurrentContext() == m_eglContext, "Embedded GL renderer used without its borrowed context current");
+        return;
+    }
+
     if (eglGetCurrentContext() != m_eglContext)
         eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglContext);
 }
@@ -358,6 +364,87 @@ static std::string processShader(const std::string& filename, const std::map<std
     auto source = loadShader(filename);
     processShaderIncludes(source, includes);
     return source;
+}
+
+void COpenGLRenderer::initGLResources() {
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
+
+    auto* const EXTENSIONS = rc<const char*>(glGetString(GL_EXTENSIONS));
+    RASSERT(EXTENSIONS, "Couldn't retrieve openGL extensions!");
+
+    std::map<std::string, std::string> includes;
+    loadShaderInclude("rounding.glsl", includes);
+    loadShaderInclude("CM.glsl", includes);
+
+    const auto VERTSRC        = processShader("tex300.vert", includes);
+    const auto FRAGBORDER1    = processShader("border.frag", includes);
+    const auto QUADFRAGSRC    = processShader("quad.frag", includes);
+    const auto TEXFRAGSRCRGBA = processShader("rgba.frag", includes);
+
+    GLuint     prog            = createProgram(VERTSRC, QUADFRAGSRC);
+    m_rectShader.program       = prog;
+    m_rectShader.proj          = glGetUniformLocation(prog, "proj");
+    m_rectShader.color         = glGetUniformLocation(prog, "color");
+    m_rectShader.posAttrib     = glGetAttribLocation(prog, "pos");
+    m_rectShader.topLeft       = glGetUniformLocation(prog, "topLeft");
+    m_rectShader.fullSize      = glGetUniformLocation(prog, "fullSize");
+    m_rectShader.radius        = glGetUniformLocation(prog, "radius");
+    m_rectShader.roundingPower = glGetUniformLocation(prog, "roundingPower");
+
+    prog                          = createProgram(VERTSRC, TEXFRAGSRCRGBA);
+    m_texShader.program           = prog;
+    m_texShader.proj              = glGetUniformLocation(prog, "proj");
+    m_texShader.tex               = glGetUniformLocation(prog, "tex");
+    m_texShader.alphaMatte        = glGetUniformLocation(prog, "texMatte");
+    m_texShader.alpha             = glGetUniformLocation(prog, "alpha");
+    m_texShader.texAttrib         = glGetAttribLocation(prog, "texcoord");
+    m_texShader.matteTexAttrib    = glGetAttribLocation(prog, "texcoordMatte");
+    m_texShader.posAttrib         = glGetAttribLocation(prog, "pos");
+    m_texShader.discardOpaque     = glGetUniformLocation(prog, "discardOpaque");
+    m_texShader.discardAlpha      = glGetUniformLocation(prog, "discardAlpha");
+    m_texShader.discardAlphaValue = glGetUniformLocation(prog, "discardAlphaValue");
+    m_texShader.topLeft           = glGetUniformLocation(prog, "topLeft");
+    m_texShader.fullSize          = glGetUniformLocation(prog, "fullSize");
+    m_texShader.radius            = glGetUniformLocation(prog, "radius");
+    m_texShader.applyTint         = glGetUniformLocation(prog, "applyTint");
+    m_texShader.tint              = glGetUniformLocation(prog, "tint");
+    m_texShader.useAlphaMatte     = glGetUniformLocation(prog, "useAlphaMatte");
+    m_texShader.roundingPower     = glGetUniformLocation(prog, "roundingPower");
+
+    prog                                 = createProgram(VERTSRC, FRAGBORDER1);
+    m_borderShader.program               = prog;
+    m_borderShader.proj                  = glGetUniformLocation(prog, "proj");
+    m_borderShader.thick                 = glGetUniformLocation(prog, "thick");
+    m_borderShader.posAttrib             = glGetAttribLocation(prog, "pos");
+    m_borderShader.texAttrib             = glGetAttribLocation(prog, "texcoord");
+    m_borderShader.topLeft               = glGetUniformLocation(prog, "topLeft");
+    m_borderShader.bottomRight           = glGetUniformLocation(prog, "bottomRight");
+    m_borderShader.fullSize              = glGetUniformLocation(prog, "fullSize");
+    m_borderShader.fullSizeUntransformed = glGetUniformLocation(prog, "fullSizeUntransformed");
+    m_borderShader.radius                = glGetUniformLocation(prog, "radius");
+    m_borderShader.radiusOuter           = glGetUniformLocation(prog, "radiusOuter");
+    m_borderShader.gradient              = glGetUniformLocation(prog, "gradient");
+    m_borderShader.gradientLength        = glGetUniformLocation(prog, "gradientLength");
+    m_borderShader.angle                 = glGetUniformLocation(prog, "angle");
+    m_borderShader.gradient2             = glGetUniformLocation(prog, "gradient2");
+    m_borderShader.gradient2Length       = glGetUniformLocation(prog, "gradient2Length");
+    m_borderShader.angle2                = glGetUniformLocation(prog, "angle2");
+    m_borderShader.gradientLerp          = glGetUniformLocation(prog, "gradientLerp");
+    m_borderShader.alpha                 = glGetUniformLocation(prog, "alpha");
+    m_borderShader.roundingPower         = glGetUniformLocation(prog, "roundingPower");
+
+    glGenVertexArrays(1, &m_vao);
+    glGenBuffers(1, &m_vbo);
+    m_polyRenderFb = makeShared<CFramebuffer>();
+}
+
+COpenGLRenderer::COpenGLRenderer() : m_borrowedContext(true) {
+    m_eglDisplay = eglGetCurrentDisplay();
+    m_eglContext = eglGetCurrentContext();
+
+    RASSERT(m_eglDisplay != EGL_NO_DISPLAY && m_eglContext != EGL_NO_CONTEXT, "Embedded GL renderer requires a current EGL GLES context");
+
+    initGLResources();
 }
 
 COpenGLRenderer::COpenGLRenderer(int drmFD) : m_drmFD(drmFD) {
@@ -431,10 +518,6 @@ COpenGLRenderer::COpenGLRenderer(int drmFD) : m_drmFD(drmFD) {
     RASSERT(success, "EGL does not support KHR_platform_gbm or EXT_platform_device, this is an issue with your gpu driver.");
 
     makeEGLCurrent();
-    glGetIntegerv(GL_MAX_TEXTURE_SIZE, cc<GLint*>(&m_maxTextureSize));
-
-    auto* const EXTENSIONS = rc<const char*>(glGetString(GL_EXTENSIONS));
-    RASSERT(EXTENSIONS, "Couldn't retrieve openGL extensions!");
 
 #if defined(__linux__)
     auto syncObjSupport = [](auto fd) {
@@ -458,73 +541,39 @@ COpenGLRenderer::COpenGLRenderer(int drmFD) : m_drmFD(drmFD) {
     glDebugMessageCallback(glMessageCallbackA, nullptr);
 #endif
 
-    std::map<std::string, std::string> includes;
-    loadShaderInclude("rounding.glsl", includes);
-    loadShaderInclude("CM.glsl", includes);
-
-    const auto VERTSRC        = processShader("tex300.vert", includes);
-    const auto FRAGBORDER1    = processShader("border.frag", includes);
-    const auto QUADFRAGSRC    = processShader("quad.frag", includes);
-    const auto TEXFRAGSRCRGBA = processShader("rgba.frag", includes);
-
-    GLuint     prog            = createProgram(VERTSRC, QUADFRAGSRC);
-    m_rectShader.program       = prog;
-    m_rectShader.proj          = glGetUniformLocation(prog, "proj");
-    m_rectShader.color         = glGetUniformLocation(prog, "color");
-    m_rectShader.posAttrib     = glGetAttribLocation(prog, "pos");
-    m_rectShader.topLeft       = glGetUniformLocation(prog, "topLeft");
-    m_rectShader.fullSize      = glGetUniformLocation(prog, "fullSize");
-    m_rectShader.radius        = glGetUniformLocation(prog, "radius");
-    m_rectShader.roundingPower = glGetUniformLocation(prog, "roundingPower");
-
-    prog                          = createProgram(VERTSRC, TEXFRAGSRCRGBA);
-    m_texShader.program           = prog;
-    m_texShader.proj              = glGetUniformLocation(prog, "proj");
-    m_texShader.tex               = glGetUniformLocation(prog, "tex");
-    m_texShader.alphaMatte        = glGetUniformLocation(prog, "texMatte");
-    m_texShader.alpha             = glGetUniformLocation(prog, "alpha");
-    m_texShader.texAttrib         = glGetAttribLocation(prog, "texcoord");
-    m_texShader.matteTexAttrib    = glGetAttribLocation(prog, "texcoordMatte");
-    m_texShader.posAttrib         = glGetAttribLocation(prog, "pos");
-    m_texShader.discardOpaque     = glGetUniformLocation(prog, "discardOpaque");
-    m_texShader.discardAlpha      = glGetUniformLocation(prog, "discardAlpha");
-    m_texShader.discardAlphaValue = glGetUniformLocation(prog, "discardAlphaValue");
-    m_texShader.topLeft           = glGetUniformLocation(prog, "topLeft");
-    m_texShader.fullSize          = glGetUniformLocation(prog, "fullSize");
-    m_texShader.radius            = glGetUniformLocation(prog, "radius");
-    m_texShader.applyTint         = glGetUniformLocation(prog, "applyTint");
-    m_texShader.tint              = glGetUniformLocation(prog, "tint");
-    m_texShader.useAlphaMatte     = glGetUniformLocation(prog, "useAlphaMatte");
-    m_texShader.roundingPower     = glGetUniformLocation(prog, "roundingPower");
-
-    prog                                 = createProgram(VERTSRC, FRAGBORDER1);
-    m_borderShader.program               = prog;
-    m_borderShader.proj                  = glGetUniformLocation(prog, "proj");
-    m_borderShader.thick                 = glGetUniformLocation(prog, "thick");
-    m_borderShader.posAttrib             = glGetAttribLocation(prog, "pos");
-    m_borderShader.texAttrib             = glGetAttribLocation(prog, "texcoord");
-    m_borderShader.topLeft               = glGetUniformLocation(prog, "topLeft");
-    m_borderShader.bottomRight           = glGetUniformLocation(prog, "bottomRight");
-    m_borderShader.fullSize              = glGetUniformLocation(prog, "fullSize");
-    m_borderShader.fullSizeUntransformed = glGetUniformLocation(prog, "fullSizeUntransformed");
-    m_borderShader.radius                = glGetUniformLocation(prog, "radius");
-    m_borderShader.radiusOuter           = glGetUniformLocation(prog, "radiusOuter");
-    m_borderShader.gradient              = glGetUniformLocation(prog, "gradient");
-    m_borderShader.gradientLength        = glGetUniformLocation(prog, "gradientLength");
-    m_borderShader.angle                 = glGetUniformLocation(prog, "angle");
-    m_borderShader.gradient2             = glGetUniformLocation(prog, "gradient2");
-    m_borderShader.gradient2Length       = glGetUniformLocation(prog, "gradient2Length");
-    m_borderShader.angle2                = glGetUniformLocation(prog, "angle2");
-    m_borderShader.gradientLerp          = glGetUniformLocation(prog, "gradientLerp");
-    m_borderShader.alpha                 = glGetUniformLocation(prog, "alpha");
-    m_borderShader.roundingPower         = glGetUniformLocation(prog, "roundingPower");
-
-    m_polyRenderFb = makeShared<CFramebuffer>();
+    initGLResources();
 
     RASSERT(eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT), "Couldn't unset current EGL!");
 }
 
 COpenGLRenderer::~COpenGLRenderer() {
+    makeEGLCurrent();
+    if (m_borrowedContext)
+        saveGLState();
+    runQueuedGL();
+
+    m_currentRBO.reset();
+    m_rbos.clear();
+    for (const auto& texture : m_textures) {
+        if (texture)
+            texture->releaseFromRenderer();
+    }
+    m_textures.clear();
+    m_polyRenderFb.reset();
+    m_rectShader.destroy();
+    m_texShader.destroy();
+    m_borderShader.destroy();
+
+    if (m_vao)
+        glDeleteVertexArrays(1, &m_vao);
+    if (m_vbo)
+        glDeleteBuffers(1, &m_vbo);
+
+    if (m_borrowedContext) {
+        restoreGLState();
+        return;
+    }
+
     if (m_eglDisplay && m_eglContext != EGL_NO_CONTEXT)
         eglDestroyContext(m_eglDisplay, m_eglContext);
 
@@ -538,7 +587,7 @@ COpenGLRenderer::~COpenGLRenderer() {
 }
 
 bool COpenGLRenderer::explicitSyncSupported() {
-    return !Env::envEnabled("HT_NO_EXPLICIT_SYNC") && m_syncobjSupported && m_exts.EGL_ANDROID_native_fence_sync_ext;
+    return !m_borrowedContext && !Env::envEnabled("HT_NO_EXPLICIT_SYNC") && m_syncobjSupported && m_exts.EGL_ANDROID_native_fence_sync_ext;
 }
 
 int COpenGLRenderer::getMaxTextureSize() {
@@ -567,7 +616,7 @@ SP<CRenderbuffer> COpenGLRenderer::getRBO(SP<Aquamarine::IBuffer> buf) {
             return r;
     }
 
-    auto rbo = m_rbos.emplace_back(makeShared<CRenderbuffer>(buf, buf->dmabuf().format));
+    auto rbo = m_rbos.emplace_back(makeShared<CRenderbuffer>(*this, buf, buf->dmabuf().format));
 
     RASSERT(rbo->good(), "GL: Couldn't make a rbo for a render");
 
@@ -595,12 +644,196 @@ void COpenGLRenderer::beginRendering(SP<IToolkitWindow> window, SP<Aquamarine::I
     m_currentRBO = getRBO(buf);
 
     m_currentRBO->bind();
+    m_targetFB = m_currentRBO->getFB()->getFBID();
+    glBindVertexArray(m_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+    prepareRenderState();
 
     m_projection      = Mat3x3::outputProjection(window->pixelSize(), HYPRUTILS_TRANSFORM_FLIPPED_180);
     m_currentViewport = window->pixelSize();
     m_scale           = window->scale();
     m_window          = window;
     m_damage          = window->m_damageRing.getBufferDamage(DAMAGE_RING_PREVIOUS_LEN);
+}
+
+void COpenGLRenderer::saveGLState() {
+    glGetIntegerv(GL_CURRENT_PROGRAM, &m_savedState.program);
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &m_savedState.drawFramebuffer);
+    glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &m_savedState.readFramebuffer);
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &m_savedState.vertexArray);
+    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &m_savedState.arrayBuffer);
+    glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, &m_savedState.pixelUnpackBuffer);
+    glGetIntegerv(GL_VIEWPORT, m_savedState.viewport);
+    glGetIntegerv(GL_SCISSOR_BOX, m_savedState.scissorBox);
+    glGetFloatv(GL_COLOR_CLEAR_VALUE, m_savedState.clearColor);
+    glGetIntegerv(GL_BLEND_SRC_RGB, &m_savedState.blendSrcRGB);
+    glGetIntegerv(GL_BLEND_DST_RGB, &m_savedState.blendDstRGB);
+    glGetIntegerv(GL_BLEND_SRC_ALPHA, &m_savedState.blendSrcAlpha);
+    glGetIntegerv(GL_BLEND_DST_ALPHA, &m_savedState.blendDstAlpha);
+    glGetIntegerv(GL_BLEND_EQUATION_RGB, &m_savedState.blendEquationRGB);
+    glGetIntegerv(GL_BLEND_EQUATION_ALPHA, &m_savedState.blendEquationAlpha);
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &m_savedState.activeTexture);
+    glGetIntegerv(GL_UNPACK_ALIGNMENT, &m_savedState.unpackAlignment);
+    glGetIntegerv(GL_UNPACK_ROW_LENGTH, &m_savedState.unpackRowLength);
+    glGetIntegerv(GL_UNPACK_SKIP_PIXELS, &m_savedState.unpackSkipPixels);
+    glGetIntegerv(GL_UNPACK_SKIP_ROWS, &m_savedState.unpackSkipRows);
+    glGetIntegerv(GL_UNPACK_IMAGE_HEIGHT, &m_savedState.unpackImageHeight);
+    glGetIntegerv(GL_UNPACK_SKIP_IMAGES, &m_savedState.unpackSkipImages);
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &m_savedState.texture2D);
+    m_savedState.blend               = glIsEnabled(GL_BLEND);
+    m_savedState.scissor             = glIsEnabled(GL_SCISSOR_TEST);
+    m_savedState.depth               = glIsEnabled(GL_DEPTH_TEST);
+    m_savedState.stencil             = glIsEnabled(GL_STENCIL_TEST);
+    m_savedState.cull                = glIsEnabled(GL_CULL_FACE);
+    m_savedState.rasterizerDiscard   = glIsEnabled(GL_RASTERIZER_DISCARD);
+    m_savedState.sampleCoverage      = glIsEnabled(GL_SAMPLE_COVERAGE);
+    m_savedState.sampleAlphaCoverage = glIsEnabled(GL_SAMPLE_ALPHA_TO_COVERAGE);
+    glGetBooleanv(GL_COLOR_WRITEMASK, m_savedState.colorMask);
+
+    if (m_savedState.activeTexture != GL_TEXTURE0) {
+        glActiveTexture(GL_TEXTURE0);
+        glGetIntegerv(GL_TEXTURE_BINDING_2D, &m_savedState.texture2DUnit0);
+        glActiveTexture(m_savedState.activeTexture);
+    } else
+        m_savedState.texture2DUnit0 = m_savedState.texture2D;
+
+    glActiveTexture(GL_TEXTURE0);
+    glGetIntegerv(GL_SAMPLER_BINDING, &m_savedState.samplerUnit0);
+    glActiveTexture(m_savedState.activeTexture);
+}
+
+bool COpenGLRenderer::contextCurrent() {
+    return eglGetCurrentContext() == m_eglContext;
+}
+
+void COpenGLRenderer::enqueueGL(std::function<void()>&& callback) {
+    std::lock_guard<std::mutex> lock(m_queuedGLMutex);
+    m_queuedGL.emplace_back(std::move(callback));
+}
+
+void COpenGLRenderer::runQueuedGL() {
+    std::vector<std::function<void()>> callbacks;
+    {
+        std::lock_guard<std::mutex> lock(m_queuedGLMutex);
+        callbacks.swap(m_queuedGL);
+    }
+
+    for (const auto& callback : callbacks)
+        callback();
+}
+
+void COpenGLRenderer::prepareRenderState() {
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_STENCIL_TEST);
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_RASTERIZER_DISCARD);
+    glDisable(GL_SAMPLE_COVERAGE);
+    glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
+    glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
+    glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 0);
+    glPixelStorei(GL_UNPACK_SKIP_IMAGES, 0);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    glBindSampler(0, 0);
+}
+
+void COpenGLRenderer::uploadVertices(const float* data, size_t size) {
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+    glBufferData(GL_ARRAY_BUFFER, size, data, GL_STREAM_DRAW);
+}
+
+void COpenGLRenderer::registerTexture(const SP<CGLTexture>& texture) {
+    m_textures.emplace_back(texture);
+}
+
+void COpenGLRenderer::restoreGLState() {
+    glUseProgram(m_savedState.program);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_savedState.drawFramebuffer);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_savedState.readFramebuffer);
+    glBindVertexArray(m_savedState.vertexArray);
+    glBindBuffer(GL_ARRAY_BUFFER, m_savedState.arrayBuffer);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, m_savedState.pixelUnpackBuffer);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, m_savedState.unpackAlignment);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, m_savedState.unpackRowLength);
+    glPixelStorei(GL_UNPACK_SKIP_PIXELS, m_savedState.unpackSkipPixels);
+    glPixelStorei(GL_UNPACK_SKIP_ROWS, m_savedState.unpackSkipRows);
+    glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, m_savedState.unpackImageHeight);
+    glPixelStorei(GL_UNPACK_SKIP_IMAGES, m_savedState.unpackSkipImages);
+    glViewport(m_savedState.viewport[0], m_savedState.viewport[1], m_savedState.viewport[2], m_savedState.viewport[3]);
+    glScissor(m_savedState.scissorBox[0], m_savedState.scissorBox[1], m_savedState.scissorBox[2], m_savedState.scissorBox[3]);
+    glClearColor(m_savedState.clearColor[0], m_savedState.clearColor[1], m_savedState.clearColor[2], m_savedState.clearColor[3]);
+    glBlendFuncSeparate(m_savedState.blendSrcRGB, m_savedState.blendDstRGB, m_savedState.blendSrcAlpha, m_savedState.blendDstAlpha);
+    glBlendEquationSeparate(m_savedState.blendEquationRGB, m_savedState.blendEquationAlpha);
+    glColorMask(m_savedState.colorMask[0], m_savedState.colorMask[1], m_savedState.colorMask[2], m_savedState.colorMask[3]);
+
+    if (m_savedState.blend)
+        glEnable(GL_BLEND);
+    else
+        glDisable(GL_BLEND);
+
+    if (m_savedState.scissor)
+        glEnable(GL_SCISSOR_TEST);
+    else
+        glDisable(GL_SCISSOR_TEST);
+
+    if (m_savedState.depth)
+        glEnable(GL_DEPTH_TEST);
+    else
+        glDisable(GL_DEPTH_TEST);
+
+    if (m_savedState.stencil)
+        glEnable(GL_STENCIL_TEST);
+    else
+        glDisable(GL_STENCIL_TEST);
+
+    if (m_savedState.cull)
+        glEnable(GL_CULL_FACE);
+    else
+        glDisable(GL_CULL_FACE);
+
+    if (m_savedState.rasterizerDiscard)
+        glEnable(GL_RASTERIZER_DISCARD);
+    else
+        glDisable(GL_RASTERIZER_DISCARD);
+
+    if (m_savedState.sampleCoverage)
+        glEnable(GL_SAMPLE_COVERAGE);
+    else
+        glDisable(GL_SAMPLE_COVERAGE);
+
+    if (m_savedState.sampleAlphaCoverage)
+        glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+    else
+        glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, m_savedState.texture2DUnit0);
+    glBindSampler(0, m_savedState.samplerUnit0);
+    glActiveTexture(m_savedState.activeTexture);
+    glBindTexture(GL_TEXTURE_2D, m_savedState.texture2D);
+}
+
+void COpenGLRenderer::beginRenderingExternal(SP<IToolkitWindow> window, uint32_t bufferAge) {
+    RASSERT(m_borrowedContext, "External framebuffer rendering requires a borrowed GL renderer");
+    makeEGLCurrent();
+    saveGLState();
+
+    m_targetFB = m_savedState.drawFramebuffer;
+    glBindVertexArray(m_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+    runQueuedGL();
+    prepareRenderState();
+
+    m_projection      = Mat3x3::outputProjection(window->pixelSize(), HYPRUTILS_TRANSFORM_FLIPPED_180);
+    m_currentViewport = window->pixelSize();
+    m_scale           = window->scale();
+    m_window          = window;
+    m_damage          = window->m_damageRing.getBufferDamage(bufferAge);
+    m_lastScissorBox  = {};
 }
 
 void COpenGLRenderer::render(bool ignoreSync) {
@@ -686,15 +919,21 @@ void COpenGLRenderer::renderBreadthfirst(SP<IElement> e) {
 }
 
 void COpenGLRenderer::endRendering() {
-    m_currentRBO->unbind();
-    m_currentRBO.reset();
+    if (m_currentRBO) {
+        m_currentRBO->unbind();
+        m_currentRBO.reset();
 
-    // FIXME: explicit sync for nvidia!!!!
-    glFlush();
+        // FIXME: explicit sync for nvidia!!!!
+        glFlush();
+        glBindVertexArray(0);
+    }
 
     m_window->m_damageRing.rotate();
     m_window.reset();
     m_damage.clear();
+
+    if (m_borrowedContext)
+        restoreGLState();
 }
 
 void COpenGLRenderer::scissor(const pixman_box32_t* box) {
@@ -712,9 +951,6 @@ void COpenGLRenderer::scissor(const pixman_box32_t* box) {
 }
 
 void COpenGLRenderer::scissor(const CBox& box) {
-    // only call glScissor if the box has changed
-    static CBox m_lastScissorBox = {};
-
     if (box.empty()) {
         glDisable(GL_SCISSOR_TEST);
         return;
@@ -768,7 +1004,8 @@ void COpenGLRenderer::renderRectangle(const SRectangleRenderData& data) {
     glUniform1f(m_rectShader.radius, data.rounding * m_scale);
     glUniform1f(m_rectShader.roundingPower, 2);
 
-    glVertexAttribPointer(m_rectShader.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
+    uploadVertices(fullVerts, sizeof(fullVerts));
+    glVertexAttribPointer(m_rectShader.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
 
     glEnableVertexAttribArray(m_rectShader.posAttrib);
 
@@ -782,6 +1019,7 @@ void COpenGLRenderer::renderRectangle(const SRectangleRenderData& data) {
 
 SP<IRendererTexture> COpenGLRenderer::uploadTexture(const STextureData& data) {
     const auto TEX = makeShared<CGLTexture>();
+    registerTexture(TEX);
     TEX->m_fitMode = data.fitMode;
     TEX->attachAsync(TEX, data.resource);
     return TEX;
@@ -923,21 +1161,23 @@ void COpenGLRenderer::renderTexture(const STextureRenderData& data) {
     } else
         glUniform1i(shader->applyTint, 0);
 
-    std::array<float, 8> texVerts;
-    if (data.texture->fitMode() == IMAGE_FIT_MODE_STRETCH || data.texture->fitMode() == IMAGE_FIT_MODE_CONTAIN) {
-        glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
-        glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
-    } else if (data.texture->fitMode() == IMAGE_FIT_MODE_COVER) {
+    std::array<float, 8> texVerts = {
+        fullVerts[0], fullVerts[1], fullVerts[2], fullVerts[3], fullVerts[4], fullVerts[5], fullVerts[6], fullVerts[7],
+    };
+    if (data.texture->fitMode() == IMAGE_FIT_MODE_COVER)
         texVerts = coverImage(data.box, tex->m_size);
-        glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
-        glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, texVerts.data());
-    } else if (data.texture->fitMode() == IMAGE_FIT_MODE_TILE) {
+    else if (data.texture->fitMode() == IMAGE_FIT_MODE_TILE) {
         texVerts = tileImage(data.box, tex->m_size);
-        glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
-        glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, texVerts.data());
         glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_S, GL_REPEAT);
         glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_T, GL_REPEAT);
     }
+
+    std::array<float, 16> vertices;
+    std::ranges::copy(fullVerts, vertices.begin());
+    std::ranges::copy(texVerts, vertices.begin() + 8);
+    uploadVertices(vertices.data(), sizeof(vertices));
+    glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+    glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, rc<const void*>(sizeof(fullVerts)));
 
     glEnableVertexAttribArray(shader->posAttrib);
     glEnableVertexAttribArray(shader->texAttrib);
@@ -997,8 +1237,9 @@ void COpenGLRenderer::renderBorder(const SBorderRenderData& data) {
     glUniform1f(m_borderShader.roundingPower, 2);
     glUniform1f(m_borderShader.thick, data.thick * m_scale);
 
-    glVertexAttribPointer(m_borderShader.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
-    glVertexAttribPointer(m_borderShader.texAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
+    uploadVertices(fullVerts, sizeof(fullVerts));
+    glVertexAttribPointer(m_borderShader.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+    glVertexAttribPointer(m_borderShader.texAttrib, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
 
     glEnableVertexAttribArray(m_borderShader.posAttrib);
     glEnableVertexAttribArray(m_borderShader.texAttrib);
@@ -1058,7 +1299,8 @@ void COpenGLRenderer::renderPolygon(const SPolygonRenderData& data) {
         verts[1 + (i * 2)] = data.poly.m_points[i].y;
     }
 
-    glVertexAttribPointer(m_rectShader.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, verts.data());
+    uploadVertices(verts.data(), verts.size() * sizeof(float));
+    glVertexAttribPointer(m_rectShader.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
 
     glEnableVertexAttribArray(m_rectShader.posAttrib);
 
@@ -1068,7 +1310,7 @@ void COpenGLRenderer::renderPolygon(const SPolygonRenderData& data) {
 
     // bind back to our fbo and render
     auto tex = m_polyRenderFb->getTexture();
-    m_currentRBO->bind();
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_targetFB);
 
     glViewport(0, 0, m_currentViewport.x, m_currentViewport.y);
 
@@ -1151,7 +1393,7 @@ void COpenGLRenderer::signalRenderPoint(SP<CSyncTimeline> timeline) {
     auto sync = CEGLSync::create();
 
     if (sync && sync->isValid()) {
-        g_backend->doOnReadable(sync->takeFd(), [ap = timeline->m_acquirePoint, tl = WP<CSyncTimeline>{timeline}]() {
+        g_backendServices->doOnReadable(sync->takeFd(), [ap = timeline->m_acquirePoint, tl = WP<CSyncTimeline>{timeline}]() {
             if (!tl)
                 return;
 

--- a/src/renderer/gl/OpenGL.hpp
+++ b/src/renderer/gl/OpenGL.hpp
@@ -15,6 +15,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <gbm.h>
+#include <mutex>
 
 namespace Hyprtoolkit {
     class IToolkitWindow;
@@ -27,9 +28,11 @@ namespace Hyprtoolkit {
     class COpenGLRenderer : public IRenderer {
       public:
         COpenGLRenderer(int drmFD);
+        COpenGLRenderer();
         virtual ~COpenGLRenderer();
 
         virtual void                 beginRendering(SP<IToolkitWindow> window, SP<Aquamarine::IBuffer> buf);
+        virtual void                 beginRenderingExternal(SP<IToolkitWindow> window, uint32_t bufferAge);
         virtual void                 render(bool ignoreSync);
         virtual void                 endRendering();
         virtual void                 renderRectangle(const SRectangleRenderData& data);
@@ -56,6 +59,7 @@ namespace Hyprtoolkit {
         void                           waitOnSync();
 
         void                           initEGL(bool gbm);
+        void                           initGLResources();
         EGLDeviceEXT                   eglDeviceFromDRMFD(int drmFD);
         EGLImageKHR                    createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
         void                           makeEGLCurrent();
@@ -71,7 +75,8 @@ namespace Hyprtoolkit {
         bool                           m_hasModifiers     = true;
         int                            m_drmFD            = -1;
         bool                           m_syncobjSupported = false;
-        const GLint                    m_maxTextureSize   = 0;
+        bool                           m_borrowedContext  = false;
+        GLint                          m_maxTextureSize   = 0;
 
         struct {
             PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC glEGLImageTargetRenderbufferStorageOES = nullptr;
@@ -108,22 +113,78 @@ namespace Hyprtoolkit {
 
         std::vector<SP<CRenderbuffer>> m_rbos;
         SP<CRenderbuffer>              m_currentRBO;
+        GLuint                         m_targetFB = 0;
+        GLuint                         m_vao      = 0;
+        GLuint                         m_vbo      = 0;
 
-        std::vector<CBox>              m_clipBoxes;
-        std::vector<SP<IElement>>      m_alreadyRendered;
         SP<IElement>                   m_currentElement;
 
-        CShader                        m_rectShader;
-        CShader                        m_texShader;
-        CShader                        m_borderShader;
+        struct SGLState {
+            GLint     program             = 0;
+            GLint     drawFramebuffer     = 0;
+            GLint     readFramebuffer     = 0;
+            GLint     vertexArray         = 0;
+            GLint     arrayBuffer         = 0;
+            GLint     pixelUnpackBuffer   = 0;
+            GLint     activeTexture       = GL_TEXTURE0;
+            GLint     texture2D           = 0;
+            GLint     texture2DUnit0      = 0;
+            GLint     viewport[4]         = {};
+            GLint     scissorBox[4]       = {};
+            GLfloat   clearColor[4]       = {};
+            GLint     blendSrcRGB         = GL_ONE;
+            GLint     blendDstRGB         = GL_ZERO;
+            GLint     blendSrcAlpha       = GL_ONE;
+            GLint     blendDstAlpha       = GL_ZERO;
+            GLint     blendEquationRGB    = GL_FUNC_ADD;
+            GLint     blendEquationAlpha  = GL_FUNC_ADD;
+            GLint     samplerUnit0        = 0;
+            GLint     unpackAlignment     = 4;
+            GLint     unpackRowLength     = 0;
+            GLint     unpackSkipPixels    = 0;
+            GLint     unpackSkipRows      = 0;
+            GLint     unpackImageHeight   = 0;
+            GLint     unpackSkipImages    = 0;
+            GLboolean blend               = GL_FALSE;
+            GLboolean scissor             = GL_FALSE;
+            GLboolean depth               = GL_FALSE;
+            GLboolean stencil             = GL_FALSE;
+            GLboolean cull                = GL_FALSE;
+            GLboolean rasterizerDiscard   = GL_FALSE;
+            GLboolean sampleCoverage      = GL_FALSE;
+            GLboolean sampleAlphaCoverage = GL_FALSE;
+            GLboolean colorMask[4]        = {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE};
+        } m_savedState;
 
-        Mat3x3                         m_projMatrix = Mat3x3::identity();
-        Mat3x3                         m_projection;
+        void                               saveGLState();
+        void                               restoreGLState();
+        bool                               contextCurrent();
+        void                               enqueueGL(std::function<void()>&& callback);
+        void                               runQueuedGL();
+        void                               prepareRenderState();
+        void                               uploadVertices(const float* data, size_t size);
+        void                               registerTexture(const SP<CGLTexture>& texture);
 
-        Vector2D                       m_currentViewport;
+        std::mutex                         m_queuedGLMutex;
+        std::vector<std::function<void()>> m_queuedGL;
+        std::vector<WP<CGLTexture>>        m_textures;
+
+        std::vector<CBox>                  m_clipBoxes;
+        std::vector<SP<IElement>>          m_alreadyRendered;
+
+        CShader                            m_rectShader;
+        CShader                            m_texShader;
+        CShader                            m_borderShader;
+
+        Mat3x3                             m_projMatrix = Mat3x3::identity();
+        Mat3x3                             m_projection;
+
+        Vector2D                           m_currentViewport;
+        CBox                               m_lastScissorBox;
 
         friend class CRenderbuffer;
         friend class CGLTexture;
+        friend class CFramebuffer;
         friend class CEGLSync;
     };
 

--- a/src/renderer/gl/Renderbuffer.cpp
+++ b/src/renderer/gl/Renderbuffer.cpp
@@ -10,19 +10,19 @@
 using namespace Hyprtoolkit;
 
 CRenderbuffer::~CRenderbuffer() {
-    g_openGL->makeEGLCurrent();
+    m_renderer.makeEGLCurrent();
 
     unbind();
     m_framebuffer.release();
     glDeleteRenderbuffers(1, &m_rbo);
 
-    g_openGL->m_proc.eglDestroyImageKHR(g_openGL->m_eglDisplay, m_image);
+    m_renderer.m_proc.eglDestroyImageKHR(m_renderer.m_eglDisplay, m_image);
 }
 
-CRenderbuffer::CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : m_hlBuffer(buffer), m_drmFormat(format) {
+CRenderbuffer::CRenderbuffer(COpenGLRenderer& renderer, SP<Aquamarine::IBuffer> buffer, uint32_t format) : m_hlBuffer(buffer), m_renderer(renderer), m_drmFormat(format) {
     auto dma = buffer->dmabuf();
 
-    m_image = g_openGL->createEGLImage(dma);
+    m_image = m_renderer.createEGLImage(dma);
     if (m_image == EGL_NO_IMAGE_KHR) {
         g_logger->log(HT_LOG_ERROR, "gl: createEGLImage failed for rbo");
         return;
@@ -30,7 +30,7 @@ CRenderbuffer::CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : 
 
     glGenRenderbuffers(1, &m_rbo);
     glBindRenderbuffer(GL_RENDERBUFFER, m_rbo);
-    g_openGL->m_proc.glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, m_image);
+    m_renderer.m_proc.glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, m_image);
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
     glGenFramebuffers(1, &m_framebuffer.m_fb);
@@ -46,7 +46,7 @@ CRenderbuffer::CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : 
 
     m_framebuffer.unbind();
 
-    m_listeners.destroyBuffer = buffer->events.destroy.listen([this] { g_openGL->onRenderbufferDestroy(this); });
+    m_listeners.destroyBuffer = buffer->events.destroy.listen([this] { m_renderer.onRenderbufferDestroy(this); });
 
     m_good = true;
 }

--- a/src/renderer/gl/Renderbuffer.hpp
+++ b/src/renderer/gl/Renderbuffer.hpp
@@ -9,10 +9,11 @@ namespace Hyprtoolkit {
 
     class CSyncTimeline;
     class CEGLSync;
+    class COpenGLRenderer;
 
     class CRenderbuffer {
       public:
-        CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format);
+        CRenderbuffer(COpenGLRenderer& renderer, SP<Aquamarine::IBuffer> buffer, uint32_t format);
         ~CRenderbuffer();
 
         bool                    good();
@@ -27,11 +28,12 @@ namespace Hyprtoolkit {
         SP<CSyncTimeline>       m_syncTimeline;
 
       private:
-        void*        m_image = nullptr;
-        GLuint       m_rbo   = 0;
-        CFramebuffer m_framebuffer;
-        uint32_t     m_drmFormat = 0;
-        bool         m_good      = false;
+        COpenGLRenderer& m_renderer;
+        void*            m_image = nullptr;
+        GLuint           m_rbo   = 0;
+        CFramebuffer     m_framebuffer;
+        uint32_t         m_drmFormat = 0;
+        bool             m_good      = false;
 
         struct {
             Hyprutils::Signal::CHyprSignalListener destroyBuffer;

--- a/src/renderer/gl/Shader.cpp
+++ b/src/renderer/gl/Shader.cpp
@@ -17,7 +17,8 @@ CShader::~CShader() {
 }
 
 void CShader::destroy() {
-    glDeleteProgram(program);
+    if (program)
+        glDeleteProgram(program);
 
     program = 0;
 }

--- a/src/renderer/sync/SyncTimeline.cpp
+++ b/src/renderer/sync/SyncTimeline.cpp
@@ -1,6 +1,7 @@
 #include "SyncTimeline.hpp"
 #include "../../Macros.hpp"
 #include "../../core/InternalBackend.hpp"
+#include "../../core/BackendContext.hpp"
 #include "../Renderer.hpp"
 
 #include <xf86drm.h>
@@ -73,6 +74,9 @@ std::optional<bool> CSyncTimeline::check(uint64_t point, uint32_t flags) {
 }
 
 bool CSyncTimeline::addWaiter(std::function<void()>&& waiter, uint64_t point, uint32_t flags) {
+    if (!g_backendServices || !g_backendServices->doOnReadable)
+        return false;
+
     auto eventFd = CFileDescriptor(eventfd(0, EFD_CLOEXEC));
 
     if (!eventFd.isValid()) {
@@ -85,7 +89,7 @@ bool CSyncTimeline::addWaiter(std::function<void()>&& waiter, uint64_t point, ui
         return false;
     }
 
-    g_backend->doOnReadable(std::move(eventFd), std::move(waiter));
+    g_backendServices->doOnReadable(std::move(eventFd), std::move(waiter));
 
     return true;
 }

--- a/src/resource/assetCache/AssetCache.cpp
+++ b/src/resource/assetCache/AssetCache.cpp
@@ -1,4 +1,5 @@
 #include "AssetCache.hpp"
+#include "../../core/BackendContext.hpp"
 
 using namespace Hyprtoolkit;
 using namespace Hyprtoolkit::Asset;
@@ -9,8 +10,11 @@ SP<CAssetCache> Asset::assetCache() {
 }
 
 SP<CAssetCacheEntry> CAssetCache::get(const std::string_view& source) {
+    if (!g_backendServices)
+        return nullptr;
+
     for (const auto& e : m_entries) {
-        if (e && e->source() == source)
+        if (e && e->source() == source && e->generation() == g_backendServices->lifetime->generation)
             return e.lock();
     }
 

--- a/src/resource/assetCache/AssetCacheEntry.cpp
+++ b/src/resource/assetCache/AssetCacheEntry.cpp
@@ -1,13 +1,15 @@
 #include "AssetCacheEntry.hpp"
+#include "../../core/BackendContext.hpp"
 
 using namespace Hyprtoolkit;
 using namespace Hyprtoolkit::Asset;
 
-CAssetCacheEntry::CAssetCacheEntry(const std::string_view& source, const SP<IRendererTexture> tex) : m_source(source), m_tex(tex), m_status(CACHE_ENTRY_DONE) {
+CAssetCacheEntry::CAssetCacheEntry(const std::string_view& source, const SP<IRendererTexture> tex) :
+    m_source(source), m_tex(tex), m_status(CACHE_ENTRY_DONE), m_generation(g_backendServices ? g_backendServices->lifetime->generation : 0) {
     ;
 }
 
-CAssetCacheEntry::CAssetCacheEntry(const std::string_view& source) : m_source(source) {
+CAssetCacheEntry::CAssetCacheEntry(const std::string_view& source) : m_source(source), m_generation(g_backendServices ? g_backendServices->lifetime->generation : 0) {
     ;
 }
 
@@ -21,6 +23,10 @@ SP<IRendererTexture> CAssetCacheEntry::tex() const {
 
 eAssetCacheEntryStatus CAssetCacheEntry::status() const {
     return m_status;
+}
+
+uint64_t CAssetCacheEntry::generation() const {
+    return m_generation;
 }
 
 void CAssetCacheEntry::texDone(SP<IRendererTexture> tex) {

--- a/src/resource/assetCache/AssetCacheEntry.hpp
+++ b/src/resource/assetCache/AssetCacheEntry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 
 #include <hyprutils/signal/Signal.hpp>
@@ -29,6 +30,7 @@ namespace Hyprtoolkit::Asset {
         std::string_view       source() const;
         SP<IRendererTexture>   tex() const;
         eAssetCacheEntryStatus status() const;
+        uint64_t               generation() const;
 
         // if created without a tex, this will mark asset as done
         void texDone(SP<IRendererTexture> tex);
@@ -44,6 +46,7 @@ namespace Hyprtoolkit::Asset {
       private:
         const std::string      m_source;
         SP<IRendererTexture>   m_tex;
-        eAssetCacheEntryStatus m_status = CACHE_ENTRY_PENDING;
+        eAssetCacheEntryStatus m_status     = CACHE_ENTRY_PENDING;
+        uint64_t               m_generation = 0;
     };
 };

--- a/src/window/Builder.cpp
+++ b/src/window/Builder.cpp
@@ -1,5 +1,6 @@
 #include "Window.hpp"
 #include "../core/InternalBackend.hpp"
+#include "../core/BackendContext.hpp"
 #include <hyprtoolkit/core/Output.hpp>
 #include "ToolkitWindow.hpp"
 
@@ -116,7 +117,10 @@ SP<IWindow> CWindowBuilder::commence() {
             return reinterpretPointerCast<IToolkitWindow>(m_data->parent)->openPopup(*m_data);
         case HT_WINDOW_TOPLEVEL:
         case HT_WINDOW_LAYER:
-        case HT_WINDOW_LOCK_SURFACE: return g_backend->openWindow(*m_data);
+        case HT_WINDOW_LOCK_SURFACE:
+            if (!g_backendServices || !g_backendServices->openWindow)
+                return nullptr;
+            return g_backendServices->openWindow(*m_data);
     }
     return nullptr;
 }

--- a/src/window/EmbeddedSurface.cpp
+++ b/src/window/EmbeddedSurface.cpp
@@ -1,0 +1,325 @@
+#include "EmbeddedSurface.hpp"
+
+#include <atomic>
+#include <hyprtoolkit/element/Null.hpp>
+
+#include "../core/AnimationManager.hpp"
+#include "../core/BackendContext.hpp"
+#include "../core/EmbeddedBackend.hpp"
+#include "../element/Element.hpp"
+#include "../renderer/Renderer.hpp"
+
+using namespace Hyprtoolkit;
+using namespace Hyprutils::Math;
+
+CEmbeddedSurface::CEmbeddedSurface() {
+    m_rootElement = CNullBuilder::begin()->commence();
+}
+
+CEmbeddedSurface::~CEmbeddedSurface() {
+    close();
+}
+
+void CEmbeddedSurface::setSelf(const SP<CEmbeddedSurface>& self, const SP<CEmbeddedBackend>& backend) {
+    static std::atomic<uint64_t> nextID = 1;
+
+    m_embeddedSelf = self;
+    m_self         = dynamicPointerCast<IToolkitWindow>(self);
+    m_backend      = backend;
+    m_id           = nextID.fetch_add(1, std::memory_order_relaxed);
+}
+
+void CEmbeddedSurface::invalidate() {
+    close();
+    m_valid = false;
+}
+
+void CEmbeddedSurface::open() {
+    if (!m_valid || m_open)
+        return;
+
+    m_open = true;
+    m_rootElement->impl->breadthfirst([this](SP<IElement> element) { element->impl->setWindow(m_self.lock()); });
+    m_needsFrame = false;
+}
+
+void CEmbeddedSurface::close() {
+    if (!m_open)
+        return;
+
+    if (g_backendServices)
+        resetIM();
+    pointerLeave();
+    unfocusKeyboard();
+    m_touchFocus.clear();
+    m_primaryTouch.reset();
+    m_rootElement->impl->breadthfirst([](SP<IElement> element) { element->impl->setWindow(nullptr); });
+    m_open = false;
+}
+
+void CEmbeddedSurface::resize(const Vector2D& logicalSize, const Vector2D& pixelSize, float scale) {
+    if (!m_valid || logicalSize.x <= 0 || logicalSize.y <= 0 || pixelSize.x <= 0 || pixelSize.y <= 0 || scale <= 0)
+        return;
+
+    m_logicalSize = logicalSize;
+    m_pixelSize   = pixelSize;
+    m_scale       = scale;
+    m_damageRing.setSize(pixelSize);
+    m_rootElement->reposition({{}, logicalSize});
+    damageEntire();
+}
+
+void CEmbeddedSurface::render(uint32_t bufferAge) {
+    if (!m_valid || !m_open || !g_renderer || m_pixelSize.x <= 0 || m_pixelSize.y <= 0)
+        return;
+
+    const auto backend = m_backend.lock();
+    if (!backend || !backend->beginFrame())
+        return;
+
+    auto renderer = g_renderer;
+    bool began    = false;
+    try {
+        m_needsFrame = false;
+        onPreRender();
+
+        renderer->beginRenderingExternal(m_self.lock(), bufferAge);
+        began = true;
+        renderer->render(true);
+        renderer->endRendering();
+        began = false;
+
+        if (g_animationManager->shouldTickForNext())
+            scheduleFrame();
+    } catch (...) {
+        if (began)
+            renderer->endRendering();
+        renderer.reset();
+        backend->endFrame();
+        throw;
+    }
+    renderer.reset();
+    backend->endFrame();
+}
+
+void CEmbeddedSurface::render() {
+    render(1);
+}
+
+void CEmbeddedSurface::scheduleFrame() {
+    if (!m_valid || m_needsFrame)
+        return;
+
+    m_needsFrame = true;
+    IEmbeddedSurface::m_events.frameRequested.emit();
+}
+
+void CEmbeddedSurface::damage(CRegion&& region) {
+    if (!m_valid)
+        return;
+
+    auto logical = region.copy();
+    IToolkitWindow::damage(std::move(region));
+    IEmbeddedSurface::m_events.damaged.emit(logical);
+}
+
+void CEmbeddedSurface::damageEntire() {
+    if (!m_valid)
+        return;
+
+    m_damageRing.damageEntire();
+    scheduleFrame();
+    IEmbeddedSurface::m_events.damaged.emit(CRegion{CBox{{}, m_logicalSize}});
+}
+
+Vector2D CEmbeddedSurface::pixelSize() {
+    return m_pixelSize;
+}
+
+float CEmbeddedSurface::scale() {
+    return m_scale;
+}
+
+SP<IElement> CEmbeddedSurface::rootElement() {
+    return m_rootElement;
+}
+
+EmbeddedSurfaceID CEmbeddedSurface::id() {
+    return m_id;
+}
+
+void CEmbeddedSurface::pointerEnter(const Vector2D& local) {
+    if (!m_valid)
+        return;
+    mouseEnter(local);
+}
+
+void CEmbeddedSurface::pointerMotion(const Vector2D& local) {
+    if (!m_valid)
+        return;
+    mouseMove(local);
+}
+
+void CEmbeddedSurface::pointerButton(Input::eMouseButton button, bool pressed) {
+    if (!m_valid)
+        return;
+    mouseButton(button, pressed);
+}
+
+void CEmbeddedSurface::pointerAxis(Input::eAxisAxis axis, float delta) {
+    if (!m_valid)
+        return;
+    mouseAxis(axis, delta);
+}
+
+void CEmbeddedSurface::pointerLeave() {
+    mouseLeave();
+}
+
+void CEmbeddedSurface::keyboardEnter() {
+    ;
+}
+
+void CEmbeddedSurface::keyboardKey(const Input::SKeyboardKeyEvent& event) {
+    if (!m_valid)
+        return;
+    IToolkitWindow::keyboardKey(event);
+}
+
+void CEmbeddedSurface::keyboardLeave() {
+    unfocusKeyboard();
+}
+
+void CEmbeddedSurface::imCommit(const std::string& text) {
+    if (!m_valid || !m_keyboardFocus)
+        return;
+    m_keyboardFocus->imCommitNewText(text);
+}
+
+void CEmbeddedSurface::imApply() {
+    if (!m_valid || !m_keyboardFocus)
+        return;
+    m_keyboardFocus->imApplyText();
+}
+
+bool CEmbeddedSurface::clippedAt(SP<IElement> element, const Vector2D& local) {
+    auto parent = element->impl->parent;
+    while (parent) {
+        if (parent->impl->clipChildren && !parent->impl->position.containsPoint(local))
+            return true;
+        parent = parent->impl->parent;
+    }
+    return false;
+}
+
+SP<IElement> CEmbeddedSurface::touchTarget(const Vector2D& local) {
+    SP<IElement> target;
+    m_rootElement->impl->breadthfirst([this, &target, local](SP<IElement> element) {
+        if (!element->acceptsTouchInput() || !element->impl->position.containsPoint(local) || clippedAt(element, local))
+            return;
+        target = element;
+    });
+    return target;
+}
+
+void CEmbeddedSurface::touchDown(int32_t id, const Vector2D& local, uint32_t timeMs) {
+    if (!m_valid || m_touchFocus.contains(id))
+        return;
+
+    if (const auto target = touchTarget(local)) {
+        const auto elementLocal = local - target->impl->position.pos();
+        m_touchFocus.emplace(id, STouchFocus{.element = target, .lastLocal = elementLocal});
+        target->impl->m_externalEvents.touchDown.emit(Input::STouchEvent{.id = id, .local = elementLocal, .timeMs = timeMs});
+        return;
+    }
+
+    if (m_primaryTouch)
+        return;
+
+    m_primaryTouch = id;
+    pointerEnter(local);
+    m_mouseIsDown = true;
+}
+
+void CEmbeddedSurface::touchMotion(int32_t id, const Vector2D& local, uint32_t timeMs) {
+    if (!m_valid)
+        return;
+
+    if (const auto focus = m_touchFocus.find(id); focus != m_touchFocus.end()) {
+        if (const auto target = focus->second.element.lock()) {
+            focus->second.lastLocal = local - target->impl->position.pos();
+            target->impl->m_externalEvents.touchMotion.emit(Input::STouchEvent{.id = id, .local = focus->second.lastLocal, .timeMs = timeMs});
+        }
+        return;
+    }
+
+    if (m_primaryTouch == id)
+        pointerMotion(local);
+}
+
+void CEmbeddedSurface::touchUp(int32_t id, uint32_t timeMs) {
+    if (!m_valid)
+        return;
+
+    if (const auto focus = m_touchFocus.find(id); focus != m_touchFocus.end()) {
+        if (const auto target = focus->second.element.lock())
+            target->impl->m_externalEvents.touchUp.emit(Input::STouchEvent{.id = id, .local = focus->second.lastLocal, .timeMs = timeMs});
+        m_touchFocus.erase(focus);
+        return;
+    }
+
+    if (m_primaryTouch != id)
+        return;
+
+    pointerButton(Input::MOUSE_BUTTON_LEFT, true);
+    pointerButton(Input::MOUSE_BUTTON_LEFT, false);
+    pointerLeave();
+    m_primaryTouch.reset();
+}
+
+void CEmbeddedSurface::touchCancel(int32_t id, uint32_t timeMs) {
+    if (!m_valid)
+        return;
+
+    if (const auto focus = m_touchFocus.find(id); focus != m_touchFocus.end()) {
+        if (const auto target = focus->second.element.lock())
+            target->impl->m_externalEvents.touchCancel.emit(Input::STouchEvent{.id = id, .local = focus->second.lastLocal, .timeMs = timeMs});
+        m_touchFocus.erase(focus);
+        return;
+    }
+
+    if (m_primaryTouch != id)
+        return;
+
+    pointerLeave();
+    m_mouseIsDown = false;
+    m_primaryTouch.reset();
+}
+
+void CEmbeddedSurface::setCursor(ePointerShape shape) {
+    if (!m_valid || !g_backendServices)
+        return;
+
+    g_backendServices->cursor->setShape(m_id, shape);
+    IEmbeddedSurface::m_events.cursorChanged.emit(shape);
+}
+
+void CEmbeddedSurface::setIMTo(const CBox& box, const std::string& text, size_t cursor) {
+    if (!m_valid || !g_backendServices)
+        return;
+
+    m_currentInput       = text;
+    m_currentInputCursor = cursor;
+    g_backendServices->textInput->activate(m_id, box, text, cursor);
+}
+
+void CEmbeddedSurface::resetIM() {
+    m_currentInput.clear();
+    m_currentInputCursor = 0;
+    if (g_backendServices)
+        g_backendServices->textInput->deactivate(m_id);
+}
+
+SP<IWindow> CEmbeddedSurface::openPopup(const SWindowCreationData& data) {
+    return nullptr;
+}

--- a/src/window/EmbeddedSurface.hpp
+++ b/src/window/EmbeddedSurface.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <optional>
+#include <unordered_map>
+
+#include <hyprtoolkit/window/EmbeddedSurface.hpp>
+
+#include "ToolkitWindow.hpp"
+
+namespace Hyprtoolkit {
+    class CEmbeddedBackend;
+
+    class CEmbeddedSurface final : public IToolkitWindow, public IEmbeddedSurface {
+      public:
+        CEmbeddedSurface();
+        ~CEmbeddedSurface();
+
+        void                      resize(const Hyprutils::Math::Vector2D& logicalSize, const Hyprutils::Math::Vector2D& pixelSize, float scale) override;
+        void                      render(uint32_t bufferAge) override;
+
+        void                      pointerEnter(const Hyprutils::Math::Vector2D& local) override;
+        void                      pointerMotion(const Hyprutils::Math::Vector2D& local) override;
+        void                      pointerButton(Input::eMouseButton button, bool pressed) override;
+        void                      pointerAxis(Input::eAxisAxis axis, float delta) override;
+        void                      pointerLeave() override;
+        void                      keyboardEnter() override;
+        void                      keyboardKey(const Input::SKeyboardKeyEvent& event) override;
+        void                      keyboardLeave() override;
+        void                      imCommit(const std::string& text) override;
+        void                      imApply() override;
+        void                      touchDown(int32_t id, const Hyprutils::Math::Vector2D& local, uint32_t timeMs) override;
+        void                      touchMotion(int32_t id, const Hyprutils::Math::Vector2D& local, uint32_t timeMs) override;
+        void                      touchUp(int32_t id, uint32_t timeMs) override;
+        void                      touchCancel(int32_t id, uint32_t timeMs) override;
+
+        SP<IElement>              rootElement() override;
+        EmbeddedSurfaceID         id() override;
+
+        Hyprutils::Math::Vector2D pixelSize() override;
+        float                     scale() override;
+        void                      open() override;
+        void                      close() override;
+        void                      scheduleFrame() override;
+        void                      damage(Hyprutils::Math::CRegion&& region) override;
+        void                      damageEntire() override;
+        void                      setCursor(ePointerShape shape) override;
+        void                      setIMTo(const Hyprutils::Math::CBox& box, const std::string& text, size_t cursor) override;
+        void                      resetIM() override;
+        SP<IWindow>               openPopup(const SWindowCreationData& data) override;
+
+        void                      setSelf(const SP<CEmbeddedSurface>& self, const SP<CEmbeddedBackend>& backend);
+        void                      invalidate();
+
+      private:
+        void                      render() override;
+        SP<IElement>              touchTarget(const Hyprutils::Math::Vector2D& local);
+        bool                      clippedAt(SP<IElement> element, const Hyprutils::Math::Vector2D& local);
+
+        Hyprutils::Math::Vector2D m_logicalSize;
+        Hyprutils::Math::Vector2D m_pixelSize;
+        float                     m_scale = 1.F;
+        bool                      m_open  = false;
+        bool                      m_valid = true;
+        WP<CEmbeddedSurface>      m_embeddedSelf;
+        WP<CEmbeddedBackend>      m_backend;
+        EmbeddedSurfaceID         m_id = 0;
+
+        struct STouchFocus {
+            WP<IElement>              element;
+            Hyprutils::Math::Vector2D lastLocal;
+        };
+
+        std::unordered_map<int32_t, STouchFocus> m_touchFocus;
+        std::optional<int32_t>                   m_primaryTouch;
+    };
+}

--- a/src/window/IWaylandWindow.cpp
+++ b/src/window/IWaylandWindow.cpp
@@ -6,6 +6,7 @@
 #include "../element/Element.hpp"
 #include "../core/platforms/WaylandPlatform.hpp"
 #include "../core/InternalBackend.hpp"
+#include "../core/BackendContext.hpp"
 #include "../renderer/Renderer.hpp"
 #include "../renderer/sync/SyncTimeline.hpp"
 #include "../core/AnimationManager.hpp"
@@ -71,7 +72,7 @@ void IWaylandWindow::resizeSwapchain(const Vector2D& pixelSize) {
     m_damageRing.setSize(pixelSize);
 
     if (!m_waylandState.swapchain)
-        m_waylandState.swapchain = Aquamarine::CSwapchain::create(g_waylandPlatform->m_allocator, g_backend->m_aqBackend->getImplementations().at(0));
+        m_waylandState.swapchain = Aquamarine::CSwapchain::create(g_waylandPlatform->m_allocator, g_waylandBackend->m_aqBackend->getImplementations().at(0));
 
     m_waylandState.swapchain->reconfigure(Aquamarine::SSwapchainOptions{
         .length = 2,
@@ -233,7 +234,7 @@ float IWaylandWindow::scale() {
 }
 
 void IWaylandWindow::setCursor(ePointerShape shape) {
-    g_waylandPlatform->setCursor(shape);
+    g_backendServices->cursor->setShape(0, shape);
 }
 
 SP<IWindow> IWaylandWindow::openPopup(const SWindowCreationData& data) {
@@ -275,22 +276,14 @@ void IWaylandWindow::mouseAxis(const Input::eAxisAxis axis, float delta) {
 }
 
 void IWaylandWindow::setIMTo(const Hyprutils::Math::CBox& box, const std::string& str, size_t cursor) {
-    if (!g_waylandPlatform->m_waylandState.imState.enabled) {
-        g_waylandPlatform->m_waylandState.textInput->sendEnable();
-        g_waylandPlatform->m_waylandState.imState.enabled = true;
-    }
-    g_waylandPlatform->m_waylandState.textInput->sendSetCursorRectangle(box.x, box.y, box.w, box.h);
-    g_waylandPlatform->m_waylandState.textInput->sendCommit();
+    g_backendServices->textInput->activate(0, box, str, cursor);
 
     m_currentInput       = str;
     m_currentInputCursor = cursor;
 }
 
 void IWaylandWindow::resetIM() {
-    if (g_waylandPlatform->m_waylandState.imState.enabled) {
-        g_waylandPlatform->m_waylandState.textInput->sendDisable();
-        g_waylandPlatform->m_waylandState.imState.enabled = false;
-    }
+    g_backendServices->textInput->deactivate(0);
 
     m_currentInput       = "";
     m_currentInputCursor = 0;

--- a/tests/EmbeddedRenderer.cpp
+++ b/tests/EmbeddedRenderer.cpp
@@ -1,0 +1,184 @@
+#include <gtest/gtest.h>
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GLES3/gl32.h>
+
+#include <hyprtoolkit/core/EmbeddedBackend.hpp>
+#include <hyprtoolkit/core/Timer.hpp>
+#include <hyprtoolkit/element/Rectangle.hpp>
+#include <hyprtoolkit/window/EmbeddedSurface.hpp>
+
+using namespace Hyprtoolkit;
+using namespace Hyprutils::Memory;
+
+class CTestEventLoop final : public IEventLoop {
+  public:
+    void addFd(int fd, std::function<void()>&& callback) override {
+        ;
+    }
+
+    void removeFd(int fd) override {
+        ;
+    }
+
+    CAtomicSharedPointer<CTimer> addTimer(const TimerDuration& timeout, std::function<void(CAtomicSharedPointer<CTimer> self, void* data)> callback, void* data,
+                                          bool force) override {
+        return makeAtomicShared<CTimer>(timeout, std::move(callback), data, force);
+    }
+
+    void addIdle(const std::function<void()>& callback) override {
+        callback();
+    }
+
+    void cancelPending() override {
+        ;
+    }
+
+    void enterLoop() override {
+        ;
+    }
+};
+
+class CEmbeddedRendererTest : public testing::Test {
+  protected:
+    void SetUp() override {
+        m_display = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+        if (m_display == EGL_NO_DISPLAY || !eglInitialize(m_display, nullptr, nullptr))
+            GTEST_SKIP() << "No surfaceless EGL display";
+
+        ASSERT_TRUE(eglBindAPI(EGL_OPENGL_ES_API));
+
+        const EGLint configAttributes[] = {
+            EGL_SURFACE_TYPE, EGL_PBUFFER_BIT, EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT, EGL_RED_SIZE, 8, EGL_GREEN_SIZE, 8, EGL_BLUE_SIZE, 8, EGL_ALPHA_SIZE, 8, EGL_NONE,
+        };
+        EGLint configCount = 0;
+        ASSERT_TRUE(eglChooseConfig(m_display, configAttributes, &m_config, 1, &configCount));
+        ASSERT_EQ(configCount, 1);
+
+        const EGLint contextAttributes[] = {
+            EGL_CONTEXT_MAJOR_VERSION, 3, EGL_CONTEXT_MINOR_VERSION, 0, EGL_NONE,
+        };
+        m_context = eglCreateContext(m_display, m_config, EGL_NO_CONTEXT, contextAttributes);
+        ASSERT_NE(m_context, EGL_NO_CONTEXT);
+
+        const EGLint surfaceAttributes[] = {
+            EGL_WIDTH, 64, EGL_HEIGHT, 64, EGL_NONE,
+        };
+        m_surface = eglCreatePbufferSurface(m_display, m_config, surfaceAttributes);
+        ASSERT_NE(m_surface, EGL_NO_SURFACE);
+        ASSERT_TRUE(eglMakeCurrent(m_display, m_surface, m_surface, m_context));
+    }
+
+    void TearDown() override {
+        if (m_display == EGL_NO_DISPLAY)
+            return;
+
+        eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        if (m_surface != EGL_NO_SURFACE)
+            eglDestroySurface(m_display, m_surface);
+        if (m_context != EGL_NO_CONTEXT)
+            eglDestroyContext(m_display, m_context);
+        eglTerminate(m_display);
+    }
+
+    EGLDisplay m_display = EGL_NO_DISPLAY;
+    EGLConfig  m_config  = nullptr;
+    EGLContext m_context = EGL_NO_CONTEXT;
+    EGLSurface m_surface = EGL_NO_SURFACE;
+};
+
+TEST_F(CEmbeddedRendererTest, rendersAndRestoresHostState) {
+    IEmbeddedBackend::SCreationData creationData;
+    creationData.eventLoop = makeShared<CTestEventLoop>();
+    auto backend           = IEmbeddedBackend::create(creationData);
+    ASSERT_TRUE(backend);
+
+    auto surface = backend->createSurface();
+    ASSERT_TRUE(surface);
+
+    surface->rootElement()->addChild(CRectangleBuilder::begin()
+                                         ->color([] { return CHyprColor{1.F, 0.F, 0.F, 1.F}; })
+                                         ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
+                                         ->commence());
+    surface->resize({64, 64}, {64, 64}, 1.F);
+
+    GLuint framebuffer = 0, texture = 0, hostVAO = 0, hostVBO = 0, hostUnpackBuffer = 0;
+    glGenFramebuffers(1, &framebuffer);
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 64, 64, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+    ASSERT_EQ(glCheckFramebufferStatus(GL_FRAMEBUFFER), GL_FRAMEBUFFER_COMPLETE);
+
+    glGenVertexArrays(1, &hostVAO);
+    glGenBuffers(1, &hostVBO);
+    glGenBuffers(1, &hostUnpackBuffer);
+    glBindVertexArray(hostVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, hostVBO);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, hostUnpackBuffer);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 5);
+    glViewport(3, 4, 17, 19);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_RASTERIZER_DISCARD);
+    glColorMask(GL_FALSE, GL_TRUE, GL_FALSE, GL_TRUE);
+
+    surface->render(0);
+
+    GLint value = 0;
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &value);
+    EXPECT_EQ(value, framebuffer);
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &value);
+    EXPECT_EQ(value, hostVAO);
+    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &value);
+    EXPECT_EQ(value, hostVBO);
+    glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, &value);
+    EXPECT_EQ(value, hostUnpackBuffer);
+    glGetIntegerv(GL_UNPACK_ALIGNMENT, &value);
+    EXPECT_EQ(value, 1);
+    glGetIntegerv(GL_UNPACK_ROW_LENGTH, &value);
+    EXPECT_EQ(value, 5);
+    EXPECT_TRUE(glIsEnabled(GL_DEPTH_TEST));
+    EXPECT_TRUE(glIsEnabled(GL_RASTERIZER_DISCARD));
+
+    GLboolean colorMask[4] = {};
+    glGetBooleanv(GL_COLOR_WRITEMASK, colorMask);
+    EXPECT_FALSE(colorMask[0]);
+    EXPECT_TRUE(colorMask[1]);
+    EXPECT_FALSE(colorMask[2]);
+    EXPECT_TRUE(colorMask[3]);
+
+    GLint viewport[4] = {};
+    glGetIntegerv(GL_VIEWPORT, viewport);
+    EXPECT_EQ(viewport[0], 3);
+    EXPECT_EQ(viewport[1], 4);
+    EXPECT_EQ(viewport[2], 17);
+    EXPECT_EQ(viewport[3], 19);
+
+    GLubyte pixel[4] = {};
+    glReadPixels(32, 32, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixel);
+    EXPECT_GT(pixel[0], 240);
+    EXPECT_LT(pixel[1], 10);
+    EXPECT_LT(pixel[2], 10);
+    EXPECT_GT(pixel[3], 240);
+
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_RASTERIZER_DISCARD);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    glDeleteBuffers(1, &hostUnpackBuffer);
+    glDeleteBuffers(1, &hostVBO);
+    glDeleteVertexArrays(1, &hostVAO);
+    glDeleteFramebuffers(1, &framebuffer);
+    glDeleteTextures(1, &texture);
+
+    surface.reset();
+    backend->destroy();
+    backend.reset();
+}

--- a/tests/unit/window/EmbeddedSurface.cpp
+++ b/tests/unit/window/EmbeddedSurface.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include "core/BackendContext.hpp"
+#include "element/Element.hpp"
+#include "window/EmbeddedSurface.hpp"
+
+using namespace Hyprtoolkit;
+using namespace Hyprutils::Math;
+
+class CEmbeddedTestElement final : public IElement {
+  public:
+    static SP<CEmbeddedTestElement> create() {
+        auto element        = makeShared<CEmbeddedTestElement>();
+        element->impl->self = element;
+        return element;
+    }
+
+    void paint() override {
+        ;
+    }
+
+    Vector2D size() override {
+        return impl->position.size();
+    }
+
+    CEmbeddedTestElement() = default;
+};
+
+class CEmbeddedSurfaceTest : public testing::Test {
+  protected:
+    void SetUp() override {
+        if (!g_backendServices) {
+            g_backendServices   = makeUnique<SBackendServices>(makeDefaultBackendServices());
+            m_installedServices = true;
+        }
+
+        m_surface = makeShared<CEmbeddedSurface>();
+        m_surface->setSelf(m_surface, nullptr);
+        m_surface->open();
+    }
+
+    void TearDown() override {
+        m_surface->invalidate();
+        m_surface.reset();
+        if (m_installedServices)
+            g_backendServices.reset();
+    }
+
+    SP<CEmbeddedSurface> m_surface;
+    bool                 m_installedServices = false;
+};
+
+TEST_F(CEmbeddedSurfaceTest, frameRequestsAreCoalesced) {
+    int requests = 0;
+    m_surface->IEmbeddedSurface::m_events.frameRequested.listenStatic([&requests] { requests++; });
+
+    m_surface->resize({100, 50}, {200, 100}, 2.F);
+    m_surface->damageEntire();
+
+    EXPECT_EQ(requests, 1);
+    EXPECT_EQ(m_surface->pixelSize(), Vector2D(200, 100));
+    EXPECT_EQ(m_surface->scale(), 2.F);
+}
+
+TEST_F(CEmbeddedSurfaceTest, touchIsCapturedByInitialTarget) {
+    const auto element = CEmbeddedTestElement::create();
+    element->setReceivesTouch(true);
+    element->reposition({10, 10, 20, 20});
+    m_surface->rootElement()->addChild(element);
+
+    std::vector<Input::STouchEvent> motions;
+    element->setTouchMotion([&motions](const Input::STouchEvent& event) { motions.emplace_back(event); });
+
+    m_surface->touchDown(7, {15, 15}, 10);
+    m_surface->touchMotion(7, {80, 40}, 20);
+    m_surface->touchUp(7, 30);
+
+    ASSERT_EQ(motions.size(), 1);
+    EXPECT_EQ(motions.front().id, 7);
+    EXPECT_EQ(motions.front().local, Vector2D(70, 30));
+    EXPECT_EQ(motions.front().timeMs, 20);
+}
+
+TEST_F(CEmbeddedSurfaceTest, cancelledPrimaryTouchDoesNotClick) {
+    const auto element = CEmbeddedTestElement::create();
+    element->setReceivesMouse(true);
+    element->reposition({10, 10, 20, 20});
+    m_surface->rootElement()->addChild(element);
+
+    int buttons = 0;
+    int leaves  = 0;
+    element->setMouseButton([&buttons](Input::eMouseButton button, bool pressed) { buttons++; });
+    element->setMouseLeave([&leaves] { leaves++; });
+
+    m_surface->touchDown(4, {15, 15}, 10);
+    m_surface->touchCancel(4, 20);
+
+    EXPECT_EQ(buttons, 0);
+    EXPECT_EQ(leaves, 1);
+}
+
+TEST_F(CEmbeddedSurfaceTest, primaryTouchTapKeepsInitialPointerTarget) {
+    const auto first  = CEmbeddedTestElement::create();
+    const auto second = CEmbeddedTestElement::create();
+    first->setReceivesMouse(true);
+    second->setReceivesMouse(true);
+    first->reposition({10, 10, 20, 20});
+    second->reposition({50, 10, 20, 20});
+    m_surface->rootElement()->addChild(first);
+    m_surface->rootElement()->addChild(second);
+
+    int firstButtons  = 0;
+    int secondButtons = 0;
+    first->setMouseButton([&firstButtons](Input::eMouseButton button, bool pressed) { firstButtons++; });
+    second->setMouseButton([&secondButtons](Input::eMouseButton button, bool pressed) { secondButtons++; });
+
+    m_surface->touchDown(4, {15, 15}, 10);
+    m_surface->touchMotion(4, {55, 15}, 20);
+    m_surface->touchUp(4, 30);
+
+    EXPECT_EQ(firstButtons, 2);
+    EXPECT_EQ(secondButtons, 0);
+}
+
+TEST_F(CEmbeddedSurfaceTest, invalidatedSurfaceIgnoresHostCalls) {
+    m_surface->invalidate();
+
+    m_surface->resize({100, 50}, {200, 100}, 2.F);
+    m_surface->pointerMotion({10, 10});
+    m_surface->keyboardKey({});
+    m_surface->touchDown(1, {10, 10}, 0);
+
+    EXPECT_EQ(m_surface->pixelSize(), Vector2D{});
+}


### PR DESCRIPTION
This is a sizeable MR, mostly codex-assisted. It's a lot of glue I cba to write on holiday.

This adds a bunch of glue to be able to run hyprtoolkit embedded inside another GLES3 app (e.g. hyprland).

For now, this requires a GLES3 context. In the future, we could separate contexts and share DMABUFs (so e.g. vulkan or GL can work too) but since HL is GLES3-only, this is ok for now.

This is a plan to make some decorations (e.g. hyprland group bars) and some future things (e.g. overview) be able to reuse elements of hyprtoolkit.

This is a draft until a corresponding Hyprland MR will be made, probably for a groupbar first.