### PR TITLE
fix: replace deprecated stdenv.isBSD with stdenv.hostPlatform.isBSD

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     wayland-scanner
     wayland-protocols
   ]
-  ++ (optional stdenv.isBSD epoll-shim);
+  ++ (optional stdenv.hostPlatform.isBSD epoll-shim);
 
   env.XDG_RUNTIME_DIR = "/tmp/runtime";
 


### PR DESCRIPTION
nixpkgs 2026-05-09 deprecated stdenv.is* in favor of stdenv.hostPlatform.is*. Triggers lib.warn on every evaluation. nixpkgs package already omits this conditional.