### PR TITLE
element/text: do not cache preferred size

### DIFF
--- a/include/hyprtoolkit/types/FontTypes.hpp
+++ b/include/hyprtoolkit/types/FontTypes.hpp
@@ -18,7 +18,7 @@ namespace Hyprtoolkit {
         // in the case of ABSOLUTE, multiplier is the raw value.
         CFontSize(eSizingBase base, float multiplier = 1.F);
 
-        float ptSize();
+        float ptSize() const;
 
       private:
         eSizingBase m_base  = HT_FONT_TEXT;

--- a/src/element/text/Text.cpp
+++ b/src/element/text/Text.cpp
@@ -1,9 +1,10 @@
 #include "Text.hpp"
 
 #include <cmath>
+#include <glib-object.h>
 #include <hyprtoolkit/palette/Palette.hpp>
 #include <hyprgraphics/color/Color.hpp>
-#include <pango-1.0/pango/pangocairo.h>
+#include <pango/pango.h>
 
 #include "../../window/ToolkitWindow.hpp"
 #include "../../layout/Positioner.hpp"
@@ -43,9 +44,8 @@ SP<CTextElement> CTextElement::create(const STextData& data) {
 
 CTextElement::CTextElement(const STextData& data) : IElement(), m_impl(makeUnique<STextImpl>()) {
     m_impl->data = data;
+    m_impl->setPangoData();
     m_impl->parseText();
-    m_impl->lastFontSizeUnscaled = m_impl->data.fontSize.ptSize();
-    m_impl->preferred            = m_impl->getTextSizePreferred();
 
     impl->m_externalEvents.mouseMove.listenStatic([this](const Vector2D& pos) {
         m_impl->lastCursorPos = pos;
@@ -68,7 +68,6 @@ void CTextElement::setText(std::string text) {
 
     m_impl->data.text = std::move(text);
     m_impl->parseText();
-    m_impl->preferred = m_impl->getTextSizePreferred();
     m_impl->scheduleTexRefresh();
 
     if (impl->window)
@@ -76,11 +75,24 @@ void CTextElement::setText(std::string text) {
 }
 
 void CTextElement::replaceData(const STextData& data) {
-    const bool TEXT_DIFFERENT  = data.text != m_impl->data.text;
-    const auto COLOR           = data.color();
-    const bool COLOR_DIFFERENT = COLOR != m_impl->color->goal();
+    const bool TEXT_DIFFERENT      = data.text != m_impl->data.text;
+    const auto COLOR               = data.color();
+    const bool COLOR_DIFFERENT     = COLOR != m_impl->color->goal();
+    const bool ALIGN_DIFFERENT     = data.align != m_impl->data.align;
+    const bool ELLIPSIZE_DIFFERENT = data.noEllipsize != m_impl->data.noEllipsize;
+    const bool FONT_DIFFERENT      = data.fontFamily != m_impl->data.fontFamily || data.fontSize.ptSize() != m_impl->data.fontSize.ptSize();
 
     m_impl->data = data;
+
+    if (ALIGN_DIFFERENT)
+        m_impl->setPangoAlign();
+    if (ELLIPSIZE_DIFFERENT)
+        m_impl->setPangoEllipsize();
+    if (FONT_DIFFERENT)
+        m_impl->setPangoFont();
+    if (TEXT_DIFFERENT)
+        m_impl->parseText();
+
     if (m_impl->colorAnimationEnabled) {
         if (m_impl->color->isBeingAnimated() && (m_impl->color->getConfig() != m_impl->colorAnimationConfig || (m_impl->color->isSpringCurve() && m_impl->color->goal() != COLOR)))
             m_impl->color->setValueAndWarp(m_impl->color->value());
@@ -91,12 +103,8 @@ void CTextElement::replaceData(const STextData& data) {
         m_impl->needsTexRefresh = m_impl->needsTexRefresh || COLOR_DIFFERENT;
     }
 
-    if (m_impl->lastFontSizeUnscaled != m_impl->data.fontSize.ptSize() || TEXT_DIFFERENT) {
-        m_impl->parseText();
-        m_impl->lastFontSizeUnscaled = m_impl->data.fontSize.ptSize();
-        m_impl->preferred            = m_impl->getTextSizePreferred();
+    if (ALIGN_DIFFERENT || ELLIPSIZE_DIFFERENT || FONT_DIFFERENT || TEXT_DIFFERENT)
         m_impl->scheduleTexRefresh();
-    }
 
     if (impl->window)
         impl->window->scheduleReposition(impl->self);
@@ -131,9 +139,8 @@ void CTextElement::paint() {
         return;
     }
 
-    if ((impl->window && impl->window->scale() != m_impl->lastScale) || m_impl->needsTexRefresh) {
-        m_impl->lastScale = impl->window ? impl->window->scale() : 1.F;
-        m_impl->preferred = m_impl->getTextSizePreferred();
+    m_impl->updateScale();
+    if (m_impl->needsTexRefresh) {
         if (!m_impl->resource)
             m_impl->renderTex();
         textureToUse = m_impl->oldTex;
@@ -168,37 +175,17 @@ void CTextElement::paint() {
 }
 
 void CTextElement::reposition(const Hyprutils::Math::CBox& box, const Hyprutils::Math::Vector2D& maxSize) {
+    auto initial_position = impl->position;
+
     IElement::reposition(box);
 
-    const auto DESIRED = m_impl->preferred;
-    if (DESIRED.x > 0 && DESIRED.y > 0 && !m_impl->data.noEllipsize) {
-        const auto PREV     = m_impl->lastMaxSize;
-        m_impl->lastMaxSize = {-1, -1};
-        const auto SIZE     = box.size();
-        if (maxSize.x > 0)
-            m_impl->lastMaxSize.x = maxSize.x;
-        if (maxSize.y > 0)
-            m_impl->lastMaxSize.y = maxSize.y;
-        // clamp to the layout's available-room hint (maxSize), already applied above. only fall
-        // back to the actual box when no hint was given: an auto-sized label's box equals its own
-        // (clamped) preferred and feeds back, flip-flopping at the boundary, whereas the room hint
-        // is stable and reflects the real container, so the text settles and recovers.
-        if (maxSize.x <= 0 && SIZE.x + 1 < DESIRED.x)
-            m_impl->lastMaxSize.x = SIZE.x;
-        if (maxSize.y <= 0 && SIZE.y + 1 < DESIRED.y)
-            m_impl->lastMaxSize.y = SIZE.y;
-
-        if (PREV != m_impl->lastMaxSize) {
-            m_impl->needsTexRefresh = true;
-            const auto LAST_PREF    = m_impl->preferred;
-            m_impl->lastScale       = impl->window ? impl->window->scale() : 1.F;
-            m_impl->preferred       = m_impl->getTextSizePreferred();
-            if (impl->window && (std::abs(LAST_PREF.x - m_impl->preferred.x) > 2 || std::abs(LAST_PREF.y - m_impl->preferred.y) > 2))
-                impl->window->scheduleReposition(impl->self.lock());
-        }
-    }
+    if (initial_position != impl->position)
+        m_impl->needsTexRefresh = true;
 
     g_positioner->positionChildren(impl->self.lock());
+
+    pango_layout_set_width(m_impl->pangoData.layout, sc<int>(impl->position.size().x * PANGO_SCALE * m_impl->lastScale));
+    pango_layout_set_height(m_impl->pangoData.layout, sc<int>(impl->position.size().y * PANGO_SCALE * m_impl->lastScale));
 }
 
 void CTextElement::recheckColor() {
@@ -223,7 +210,41 @@ std::optional<Vector2D> CTextElement::maximumSize(const Hyprutils::Math::Vector2
 }
 
 std::optional<Vector2D> CTextElement::preferredSize(const Hyprutils::Math::Vector2D& parent) {
-    return m_impl->preferred;
+    auto s = m_impl->data.size.calculate(parent);
+    if (s.x != -1 && s.y != -1)
+        return s;
+
+    auto maxSize = parent - Vector2D{impl->margin * 2, impl->margin * 2};
+    if (s.x != -1)
+        maxSize.x = s.x;
+    if (s.y != -1)
+        maxSize.y = s.y;
+    maxSize = m_impl->applyClampSize(maxSize);
+
+    m_impl->updateScale();
+    auto LAYOUT = m_impl->pangoData.layout;
+    if (maxSize.x != 0)
+        pango_layout_set_width(LAYOUT, sc<int>(maxSize.x * PANGO_SCALE * m_impl->lastScale));
+    else
+        pango_layout_set_width(LAYOUT, -1);
+    if (maxSize.y != 0)
+        pango_layout_set_height(LAYOUT, sc<int>(maxSize.y * PANGO_SCALE * m_impl->lastScale));
+    else
+        pango_layout_set_height(LAYOUT, -1);
+
+    PangoRectangle ink, logical;
+    pango_layout_get_pixel_extents(LAYOUT, &ink, &logical);
+
+    auto result = Vector2D{std::ceil(logical.width / m_impl->lastScale), std::ceil(logical.height / m_impl->lastScale)} + Vector2D(impl->margin * 2, impl->margin * 2);
+    if (s.x == -1)
+        s.x = result.x;
+    if (s.y == -1)
+        s.y = result.y;
+
+    pango_layout_set_width(m_impl->pangoData.layout, sc<int>(impl->position.size().x * PANGO_SCALE * m_impl->lastScale));
+    pango_layout_set_height(m_impl->pangoData.layout, sc<int>(impl->position.size().y * PANGO_SCALE * m_impl->lastScale));
+
+    return s;
 }
 
 std::optional<Vector2D> CTextElement::minimumSize(const Hyprutils::Math::Vector2D& parent) {
@@ -242,32 +263,82 @@ bool CTextElement::positioningDependsOnChild() {
     return m_impl->data.size.hasAuto();
 }
 
-std::tuple<UP<Hyprgraphics::CCairoSurface>, cairo_t*, PangoLayout*, Vector2D> STextImpl::prepPangoLayout() {
-    auto                  CAIROSURFACE = makeUnique<CCairoSurface>(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1 /* dummy value */));
-    auto                  CAIRO        = cairo_create(CAIROSURFACE->cairo());
+SPangoData::SPangoData() : layout(nullptr), context(nullptr) {}
 
-    PangoLayout*          layout = pango_cairo_create_layout(CAIRO);
+SPangoData::SPangoData(PangoLayout* layout, PangoContext* context) : layout(layout), context(context) {}
 
+SPangoData::SPangoData(SPangoData&& other) noexcept : layout(other.layout), context(other.context) {
+    ref();
+}
+
+SPangoData& SPangoData::operator=(SPangoData&& other) noexcept {
+    if (this != &other) {
+        unref();
+
+        layout  = other.layout;
+        context = other.context;
+
+        ref();
+    }
+
+    return *this;
+}
+
+SPangoData::~SPangoData() {
+    unref();
+}
+
+void SPangoData::unref() const {
+    if (layout)
+        g_object_unref(layout);
+    if (context)
+        g_object_unref(context);
+}
+
+void SPangoData::ref() const {
+    if (layout)
+        g_object_ref(layout);
+    if (context)
+        g_object_ref(context);
+}
+
+void STextImpl::setPangoData() {
+    PangoFontMap* font_map = pango_cairo_font_map_get_default();
+    PangoContext* context  = pango_font_map_create_context(font_map);
+    PangoLayout*  layout   = pango_layout_new(context);
+
+    pangoData = {layout, context};
+
+    setPangoFont();
+    setPangoAlign();
+    setPangoEllipsize();
+}
+
+void STextImpl::setPangoFont() {
     PangoFontDescription* fontDesc = pango_font_description_from_string(data.fontFamily.c_str());
-    pango_font_description_set_size(fontDesc, std::round(lastFontSizeUnscaled * lastScale) * PANGO_SCALE);
-    pango_layout_set_font_description(layout, fontDesc);
+    pango_font_description_set_size(fontDesc, std::round(data.fontSize.ptSize() * lastScale) * PANGO_SCALE);
+    pango_layout_set_font_description(pangoData.layout, fontDesc);
     pango_font_description_free(fontDesc);
+}
 
+void STextImpl::setPangoAlign() {
     if (data.align == HT_FONT_ALIGN_LEFT)
-        pango_layout_set_alignment(layout, PANGO_ALIGN_LEFT);
+        pango_layout_set_alignment(pangoData.layout, PANGO_ALIGN_LEFT);
     else if (data.align == HT_FONT_ALIGN_CENTER)
-        pango_layout_set_alignment(layout, PANGO_ALIGN_CENTER);
+        pango_layout_set_alignment(pangoData.layout, PANGO_ALIGN_CENTER);
     else
-        pango_layout_set_alignment(layout, PANGO_ALIGN_RIGHT);
+        pango_layout_set_alignment(pangoData.layout, PANGO_ALIGN_RIGHT);
+}
 
+void STextImpl::setPangoText() {
     PangoAttrList* attrList = nullptr;
     GError*        gError   = nullptr;
     char*          buf      = nullptr;
     if (pango_parse_markup(parsedText.c_str(), -1, 0, &attrList, &buf, nullptr, &gError))
-        pango_layout_set_text(layout, buf, -1);
+        pango_layout_set_text(pangoData.layout, buf, -1);
     else {
         g_error_free(gError);
-        pango_layout_set_text(layout, parsedText.c_str(), -1);
+        pango_layout_set_text(pangoData.layout, parsedText.c_str(), -1);
     }
 
     if (!attrList)
@@ -277,52 +348,30 @@ std::tuple<UP<Hyprgraphics::CCairoSurface>, cairo_t*, PangoLayout*, Vector2D> ST
         free(buf);
 
     pango_attr_list_insert(attrList, pango_attr_scale_new(1));
-    pango_layout_set_attributes(layout, attrList);
+    pango_layout_set_attributes(pangoData.layout, attrList);
     pango_attr_list_unref(attrList);
-
-    int layoutWidth, layoutHeight;
-    pango_layout_get_size(layout, &layoutWidth, &layoutHeight);
-
-    PangoRectangle ink, logical;
-    pango_layout_get_pixel_extents(layout, &ink, &logical);
-
-    std::optional<Vector2D> maxSize = data.clampSize.value_or(lastMaxSize).round();
-    if (maxSize == Vector2D{0, 0})
-        maxSize = std::nullopt;
-
-    if (maxSize.has_value())
-        (*maxSize) *= lastScale;
-
-    if (maxSize.has_value()) {
-        const auto CLAMP_SIZE = maxSize.value();
-        if (!data.noEllipsize && maxSize.has_value() && maxSize->y >= 0)
-            pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
-        if (CLAMP_SIZE.x >= 0)
-            pango_layout_set_width(layout, std::min(logical.width * PANGO_SCALE, sc<int>(CLAMP_SIZE.x * PANGO_SCALE)));
-        if (CLAMP_SIZE.y >= 0)
-            pango_layout_set_height(layout, std::min(logical.height * PANGO_SCALE, sc<int>(CLAMP_SIZE.y * PANGO_SCALE)));
-        if (CLAMP_SIZE.x >= 0)
-            pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR);
-
-        pango_layout_get_pixel_extents(layout, &ink, &logical);
-    }
-
-    pango_layout_get_pixel_extents(layout, &ink, &logical);
-
-    return std::make_tuple<>(std::move(CAIROSURFACE), CAIRO, layout, Vector2D{logical.width, logical.height});
 }
 
-Hyprutils::Math::Vector2D STextImpl::getTextSizePreferred() {
-    auto [CAIROSURFACE, CAIRO, LAYOUT, LAYOUTSIZE] = prepPangoLayout();
+void STextImpl::setPangoEllipsize() {
+    if (data.noEllipsize) {
+        pango_layout_set_wrap(pangoData.layout, PANGO_WRAP_WORD_CHAR);
+        pango_layout_set_ellipsize(pangoData.layout, PANGO_ELLIPSIZE_NONE);
+    } else {
+        pango_layout_set_wrap(pangoData.layout, PANGO_WRAP_NONE);
+        pango_layout_set_ellipsize(pangoData.layout, PANGO_ELLIPSIZE_END);
+    }
+}
 
-    g_object_unref(LAYOUT);
-    cairo_destroy(CAIRO);
-
-    return LAYOUTSIZE / lastScale;
+void STextImpl::updateScale() {
+    if (self && self->impl->window && self->impl->window->scale() != lastScale) {
+        lastScale = self->impl->window->scale();
+        setPangoFont();
+        needsTexRefresh = true;
+    }
 }
 
 CBox STextImpl::getCharBox(size_t offset) {
-    auto [CAIROSURFACE, CAIRO, LAYOUT, LAYOUTSIZE] = prepPangoLayout();
+    auto           LAYOUT = pangoData.layout;
 
     PangoRectangle rect;
 
@@ -337,23 +386,17 @@ CBox STextImpl::getCharBox(size_t offset) {
         }
             .scale(1.F / lastScale);
 
-    g_object_unref(LAYOUT);
-    cairo_destroy(CAIRO);
-
     return charBox;
 }
 
 std::optional<size_t> STextImpl::vecToOffset(const Vector2D& vec) {
-    auto [CAIROSURFACE, CAIRO, LAYOUT, LAYOUTSIZE] = prepPangoLayout();
+    auto LAYOUT = pangoData.layout;
 
     auto pangoX = sc<int>(vec.x * PANGO_SCALE), //
         pangoY  = sc<int>(vec.y * PANGO_SCALE);
 
     int index = 0, trailing = 0;
     pango_layout_xy_to_index(LAYOUT, pangoX, pangoY, &index, &trailing);
-
-    g_object_unref(LAYOUT);
-    cairo_destroy(CAIRO);
 
     if (index == -1)
         return std::nullopt;
@@ -362,8 +405,11 @@ std::optional<size_t> STextImpl::vecToOffset(const Vector2D& vec) {
 }
 
 float STextImpl::getCursorPos(size_t offset) {
-    if (offset >= parsedText.length())
-        return preferred.x;
+    if (offset >= parsedText.length() && !parsedText.empty()) {
+        auto box = getCharBox(parsedText.length() - 1);
+        return box.x + box.size().x;
+    } else if (parsedText.empty())
+        return 0;
 
     if (offset == 0)
         return 0;
@@ -400,40 +446,32 @@ void STextImpl::renderTex() {
 
     waitingForTex = true;
 
-    lastScale = self->impl->window ? self->impl->window->scale() : 1.F;
-
     self->impl->damageEntire();
 
-    std::optional<Vector2D> maxSize = data.clampSize.value_or(lastMaxSize).round();
-    if (maxSize == Vector2D{0, 0})
-        maxSize = std::nullopt;
-
-    if (maxSize.has_value())
-        (*maxSize) *= lastScale;
-
-    const auto COLOR = colorAnimationEnabled ? CHyprColor{1.F, 1.F, 1.F, 1.F} : data.color();
-    resource         = makeAtomicShared<CTextResource>(CTextResource::STextResourceData{
-        .text      = parsedText,
-        .font      = data.fontFamily,
-        .fontSize  = sc<size_t>(std::round(lastFontSizeUnscaled * lastScale)),
-        .color     = CColor{CColor::SSRGB{.r = COLOR.r, .g = COLOR.g, .b = COLOR.b}},
-        .align     = data.align == HT_FONT_ALIGN_LEFT ?
-            Hyprgraphics::CTextResource::TEXT_ALIGN_LEFT :
-            (data.align == HT_FONT_ALIGN_CENTER ? Hyprgraphics::CTextResource::TEXT_ALIGN_CENTER : Hyprgraphics::CTextResource::TEXT_ALIGN_RIGHT),
-        .maxSize   = maxSize,
-        .ellipsize = !data.noEllipsize && maxSize.has_value() && maxSize->y >= 0,
-        .wrap      = maxSize.has_value() && maxSize->x >= 0,
+    const Vector2D MAX_SIZE = applyClampSize(self->impl->position.size()) * lastScale;
+    const auto     COLOR    = colorAnimationEnabled ? CHyprColor{1.F, 1.F, 1.F, 1.F} : data.color();
+    resource                = makeAtomicShared<CTextResource>(CTextResource::STextResourceData{
+                       .text      = parsedText,
+                       .font      = data.fontFamily,
+                       .fontSize  = sc<size_t>(std::round(data.fontSize.ptSize() * lastScale)),
+                       .color     = CColor{CColor::SSRGB{.r = COLOR.r, .g = COLOR.g, .b = COLOR.b}},
+                       .align     = data.align == HT_FONT_ALIGN_LEFT ?
+                               Hyprgraphics::CTextResource::TEXT_ALIGN_LEFT :
+                               (data.align == HT_FONT_ALIGN_CENTER ? Hyprgraphics::CTextResource::TEXT_ALIGN_CENTER : Hyprgraphics::CTextResource::TEXT_ALIGN_RIGHT),
+                       .maxSize   = MAX_SIZE,
+                       .ellipsize = !data.noEllipsize,
+                       .wrap      = data.noEllipsize,
     });
 
     if (Env::isTrace()) {
         const std::string TEXT_SHORT = data.text.size() > 20 ? data.text.substr(0, 20) + "..." : data.text;
         g_logger->log(HT_LOG_TRACE, "TextImpl: scheduling rendering of text \"{}\", with the following params:\nfont: {}, fontSize: {}, maxSize: {}, ellipsize: {}, wrap: {}",
-                      TEXT_SHORT,                                                       //
-                      data.fontFamily,                                                  //
-                      sc<size_t>(std::round(lastFontSizeUnscaled * lastScale)),         //
-                      maxSize.has_value() ? std::format("{}", *maxSize) : "<no value>", //
-                      !data.noEllipsize && maxSize.has_value() && maxSize->y >= 0,      //
-                      maxSize.has_value() && maxSize->x >= 0                            //
+                      TEXT_SHORT,                                                 //
+                      data.fontFamily,                                            //
+                      sc<size_t>(std::round(data.fontSize.ptSize() * lastScale)), //
+                      MAX_SIZE,                                                   //
+                      !data.noEllipsize,                                          //
+                      data.noEllipsize                                            //
         );
     }
 
@@ -555,6 +593,8 @@ void STextImpl::parseText() {
     }
 
     parsedText = std::move(newString);
+
+    setPangoText();
 }
 
 void STextImpl::recheckTextBoxes() {
@@ -589,4 +629,16 @@ void STextImpl::onMouseMove() {
         hoveredTextLink = &link;
         break;
     }
+}
+
+Vector2D STextImpl::applyClampSize(Vector2D size) {
+    if (!data.clampSize.has_value())
+        return size;
+
+    if (size.x <= 0 || (data.clampSize->x < size.x && data.clampSize->x > 0))
+        size.x = data.clampSize->x;
+    if (size.y <= 0 || (data.clampSize->y < size.y && data.clampSize->y > 0))
+        size.y = data.clampSize->y;
+
+    return size;
 }

--- a/src/element/text/Text.hpp
+++ b/src/element/text/Text.hpp
@@ -21,7 +21,7 @@ namespace Hyprtoolkit {
         float                                    a           = 1.F;
         bool                                     noEllipsize = false;
         std::optional<Hyprutils::Math::Vector2D> clampSize;
-        CDynamicSize                             size{CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_PERCENT, {1, 1}};
+        CDynamicSize                             size{CDynamicSize::HT_SIZE_AUTO, CDynamicSize::HT_SIZE_AUTO, {1, 1}};
         std::function<void()>                    callback; // called after resource is loaded
         bool                                     async = true;
         std::optional<bool>                      interactable;
@@ -33,6 +33,23 @@ namespace Hyprtoolkit {
         Hyprutils::Math::CRegion region;
     };
 
+    struct SPangoData {
+        PangoLayout*  layout;
+        PangoContext* context;
+
+        SPangoData();
+        SPangoData(PangoLayout* layout, PangoContext* context);
+        SPangoData(const SPangoData&) = delete;
+        SPangoData(SPangoData&&) noexcept;
+        SPangoData& operator=(const SPangoData&) = delete;
+        SPangoData& operator=(SPangoData&&) noexcept;
+
+        void        ref() const;
+        void        unref() const;
+
+        ~SPangoData();
+    };
+
     struct STextImpl {
         STextData                                                                                      data;
 
@@ -42,18 +59,17 @@ namespace Hyprtoolkit {
 
         WP<CTextElement>                                                                               self;
 
-        size_t                                                                                         lastFontSizeUnscaled = 0;
-        float                                                                                          lastScale            = 1.F;
+        float                                                                                          lastScale       = 1.F;
         bool                                                                                           needsTexRefresh = false, newTex = false;
 
-        Hyprutils::Math::Vector2D                                                                      lastMaxSize;
+        SPangoData                                                                                     pangoData;
 
         SP<IRendererTexture>                                                                           tex;
         SP<IRendererTexture>                                                                           oldTex; // while loading a new one
         PHLANIMVAR<CHyprColor>                                                                         color;
         SP<Hyprutils::Animation::SAnimationPropertyConfig>                                             colorAnimationConfig;
         ASP<Hyprgraphics::CTextResource>                                                               resource;
-        Hyprutils::Math::Vector2D                                                                      size, preferred;
+        Hyprutils::Math::Vector2D                                                                      size;
 
         Hyprutils::Math::Vector2D                                                                      lastCursorPos;
 
@@ -61,13 +77,17 @@ namespace Hyprtoolkit {
         bool                                                                                           colorAnimationEnabled = false;
         bool                                                                                           renderColorAtPaint    = false;
 
-        Hyprutils::Math::Vector2D                                                                      getTextSizePreferred();
         Hyprutils::Math::CBox                                                                          getCharBox(size_t offset);
         std::optional<size_t>                                                                          vecToOffset(const Hyprutils::Math::Vector2D& vec);
         float                                                                                          getCursorPos(size_t offset);
         float                                                                                          getCursorPos(const Hyprutils::Math::Vector2D& click);
         Hyprutils::Math::Vector2D                                                                      unscale(const Hyprutils::Math::Vector2D& x);
-        std::tuple<UP<Hyprgraphics::CCairoSurface>, cairo_t*, PangoLayout*, Hyprutils::Math::Vector2D> prepPangoLayout();
+        void                                                                                           setPangoData();
+        void                                                                                           setPangoFont();
+        void                                                                                           setPangoAlign();
+        void                                                                                           setPangoText();
+        void                                                                                           setPangoEllipsize();
+        void                                                                                           updateScale();
         void                                                                                           scheduleTexRefresh();
         void                                                                                           renderTex();
         void                                                                                           postTexLoad();
@@ -75,6 +95,7 @@ namespace Hyprtoolkit {
         void                                                                                           recheckTextBoxes();
         void                                                                                           onMouseDown();
         void                                                                                           onMouseMove();
+        Hyprutils::Math::Vector2D                                                                      applyClampSize(Hyprutils::Math::Vector2D);
 
         friend class CTextboxElement;
         friend struct STextboxImpl;

--- a/src/types/FontSizeType.cpp
+++ b/src/types/FontSizeType.cpp
@@ -9,7 +9,7 @@ CFontSize::CFontSize(eSizingBase base, float mult) : m_base(base), m_value(mult)
     ;
 }
 
-float CFontSize::ptSize() {
+float CFontSize::ptSize() const {
     switch (m_base) {
         case HT_FONT_H1: return g_palette->m_vars.h1Size * m_value;
         case HT_FONT_H2: return g_palette->m_vars.h2Size * m_value;

--- a/src/window/ToolkitWindow.cpp
+++ b/src/window/ToolkitWindow.cpp
@@ -354,7 +354,7 @@ void IToolkitWindow::openTooltip(const std::string& s, const Hyprutils::Math::Ve
 
     m_tooltip.bg->addChild(m_tooltip.text);
 
-    const auto EXPECTED_TEXT_SIZE = m_tooltip.text->m_impl->getTextSizePreferred();
+    const auto EXPECTED_TEXT_SIZE = m_tooltip.text->preferredSize({0, 0}).value();
 
     m_tooltip.tooltipPopup = reinterpretPointerCast<IToolkitWindow>(CWindowBuilder::begin()
                                                                         ->type(eWindowType::HT_WINDOW_POPUP)

--- a/tests/unit/elements/Text.cpp
+++ b/tests/unit/elements/Text.cpp
@@ -8,6 +8,13 @@
 #include <layout/Positioner.hpp>
 
 #include "../tricks/Tricks.hpp"
+#include "element/Element.hpp"
+#include "hyprtoolkit/element/Element.hpp"
+#include "hyprtoolkit/element/Null.hpp"
+#include "hyprtoolkit/element/Rectangle.hpp"
+#include "hyprtoolkit/element/RowLayout.hpp"
+#include "hyprtoolkit/types/FontTypes.hpp"
+#include "hyprtoolkit/types/SizeType.hpp"
 
 using namespace Hyprtoolkit;
 using namespace Hyprutils::Math;
@@ -25,60 +32,184 @@ TEST(Element, text) {
     text.reset();
 }
 
-// an auto label gets no room hint and its box tracks its own clamped preferred, so the box feeds
-// back into the next layout. a transient narrow box on first layout (e.g. before an async icon
-// sibling reflows the row) must not lock the text ellipsized: once the box equals the clamped
-// preferred the clamp has to release and the text recover. #94 compared the box against a cached
-// natural size, so the box-feedback condition stayed true and the ellipsis locked forever. this is
-// the hyprlauncher regression.
-TEST(Element, textEllipsizeRecoversFromTransientClamp) {
+TEST(Element, textPreferredSize) {
     Tests::Tricks::createBackendSupport();
 
-    auto text = CTextBuilder::begin()->text("Hello World Foo Bar Baz")->commence();
+    auto       text = CTextBuilder::begin()->text("Hello World Foo Bar Baz")->noEllipsize(true)->commence();
 
-    // natural width: a generous box, no room hint
-    g_positioner->position(text, {{}, {1000.F, 20.F}}, {-1.F, -1.F});
-    const float NATURAL = text->preferredSize({}).value_or(Vector2D{}).x;
-    EXPECT_GT(NATURAL, 40.F);
+    const auto NATURAL_SIZE = text->preferredSize({0, 0});
+    EXPECT_TRUE(NATURAL_SIZE.has_value());
 
-    // a transient narrow box on first layout clamps it
-    g_positioner->position(text, {{}, {NATURAL * 0.3F, 20.F}}, {-1.F, -1.F});
-    EXPECT_LT(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+    const auto CLAMPED_WIDTH = std::floor(NATURAL_SIZE->x * 3 / 4);
 
-    // from here the layout hands the auto label a box equal to its own preferred. feed that back a
-    // few frames: it must converge back to NATURAL, not stay locked at the clamped width.
-    for (int i = 0; i < 4; ++i) {
-        const auto PREF = text->preferredSize({}).value_or(Vector2D{});
-        g_positioner->position(text, {{}, PREF}, {-1.F, -1.F});
-    }
-    EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+    const auto WRAPPED_SIZE = text->preferredSize({CLAMPED_WIDTH, NATURAL_SIZE->y * 3});
+    EXPECT_TRUE(WRAPPED_SIZE.has_value());
+    EXPECT_LE(WRAPPED_SIZE->x, CLAMPED_WIDTH);
+    EXPECT_GT(WRAPPED_SIZE->y, NATURAL_SIZE->y);
+
+    text->rebuild()->noEllipsize(false)->commence();
+    const auto ELLIPSIZED_SIZE = text->preferredSize({CLAMPED_WIDTH, NATURAL_SIZE->y * 3});
+    EXPECT_TRUE(ELLIPSIZED_SIZE.has_value());
+    EXPECT_LE(ELLIPSIZED_SIZE->x, CLAMPED_WIDTH);
+    EXPECT_EQ(ELLIPSIZED_SIZE->y, NATURAL_SIZE->y);
+
+    const auto FINAL_NATURAL_SIZE = text->preferredSize({0, 0});
+    EXPECT_TRUE(FINAL_NATURAL_SIZE.has_value());
+    EXPECT_EQ(FINAL_NATURAL_SIZE->x, NATURAL_SIZE->x);
+    EXPECT_EQ(FINAL_NATURAL_SIZE->y, NATURAL_SIZE->y);
 
     text.reset();
 }
 
-// a stable room hint (e.g. the combobox row layout) clamps to the room and stays put, no per-frame
-// flicker at the fit/elide boundary.
-TEST(Element, textEllipsizeStableUnderRoomHint) {
+TEST(Element, textGrowsAgainstNeighbor) {
     Tests::Tricks::createBackendSupport();
 
-    auto        text    = CTextBuilder::begin()->text("Hello World Foo Bar Baz")->commence();
-    const float NATURAL = text->preferredSize({}).value_or(Vector2D{}).x;
-    EXPECT_GT(NATURAL, 20.F);
+    const CBox POSITION = {0, 0, 1000, 100};
 
-    const CBox     widebox = {{}, {NATURAL, 20.F}};
-    const Vector2D tight   = {NATURAL * 0.4F, 20.F};
+    auto       layout = CRowLayoutBuilder::begin()->commence();
+    auto       text   = CTextBuilder::begin()->text("Hello World Foo Bar Baz")->commence();
+    auto       rect   = CRectangleBuilder::begin()->size({CDynamicSize::HT_SIZE_AUTO, CDynamicSize::HT_SIZE_ABSOLUTE, {1, 10}})->commence();
+    rect->setGrow(true);
 
-    g_positioner->position(text, widebox, tight);
-    const float CLAMPED = text->preferredSize({}).value_or(Vector2D{}).x;
-    EXPECT_LT(CLAMPED, NATURAL);
+    layout->addChild(text);
+    layout->addChild(rect);
 
-    // same room again does not flip the size
-    g_positioner->position(text, widebox, tight);
-    EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, CLAMPED);
+    g_positioner->position(layout, POSITION);
 
-    // room grows back: recover to full
-    g_positioner->position(text, widebox, {NATURAL + 80.F, 20.F});
-    EXPECT_FLOAT_EQ(text->preferredSize({}).value_or(Vector2D{}).x, NATURAL);
+    EXPECT_EQ(rect->impl->position.width + text->impl->position.width, POSITION.width);
+    const auto PREVIOUS_TEXT_WIDTH = text->impl->position.width;
+
+    text->rebuild()->text("Hello World Foo Bar Baz but longer")->commence();
+    g_positioner->position(layout, POSITION);
+
+    EXPECT_EQ(rect->impl->position.width + text->impl->position.width, POSITION.width);
+    EXPECT_GT(text->impl->position.width, PREVIOUS_TEXT_WIDTH);
+
+    text.reset();
+    rect.reset();
+    layout.reset();
+}
+
+TEST(Element, textSideBySide) {
+    Tests::Tricks::createBackendSupport();
+
+    const CBox POSITION = {0, 0, 300, 100};
+
+    auto       text1 = CTextBuilder::begin()
+                     ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_AUTO, {0.5, 1.0}})
+                     ->text("First longish paragraph goes here. I love Hyprland it is the best.")
+                     ->noEllipsize(true)
+                     ->commence();
+    auto text2 = CTextBuilder::begin()
+                     ->size({CDynamicSize::HT_SIZE_PERCENT, CDynamicSize::HT_SIZE_AUTO, {0.5, 1.0}})
+                     ->text("Second longish paragraph goes here. Who needs GTK and Qt when you have Hyprtoolkit?")
+                     ->noEllipsize(true)
+                     ->commence();
+    auto       layout = CRowLayoutBuilder::begin()->commence();
+
+    const auto NATURAL_HEIGHT = text1->preferredSize({0, 0})->y;
+
+    layout->addChild(text1);
+    layout->addChild(text2);
+
+    g_positioner->position(layout, POSITION);
+
+    ASSERT_EQ(layout->impl->position.width, POSITION.width);
+    ASSERT_EQ(text1->impl->position.width, POSITION.width / 2);
+    ASSERT_EQ(text2->impl->position.width, POSITION.width / 2);
+    ASSERT_EQ(text1->impl->position.width, text2->impl->position.x);
+    ASSERT_GT(text1->impl->position.height, NATURAL_HEIGHT);
+    ASSERT_GT(text2->impl->position.height, NATURAL_HEIGHT);
+
+    text1.reset();
+    text2.reset();
+    layout.reset();
+}
+
+TEST(Element, textShrinkingThenGrowing) {
+    Tests::Tricks::createBackendSupport();
+
+    // This container is necessary because we need the text to auto size itself
+    // if we position it directly, the text sizing code is never run
+    auto container = CNullBuilder::begin()->commence();
+    auto text      = CTextBuilder::begin()->text("First longish paragraph goes here. I love Hyprland it is the best.")->commence();
+
+    container->addChild(text);
+
+    const auto NATURAL_WIDTH = text->preferredSize({0, 0})->x;
+    const auto CLAMPED_WIDTH = std::floor(NATURAL_WIDTH * 3 / 4);
+
+    g_positioner->position(container, {0, 0, CLAMPED_WIDTH, 100});
+    ASSERT_LE(text->impl->position.width, CLAMPED_WIDTH);
+
+    g_positioner->position(container, {0, 0, NATURAL_WIDTH * 2, 100});
+    ASSERT_EQ(text->impl->position.width, NATURAL_WIDTH);
+
+    container.reset();
+    text.reset();
+}
+
+TEST(Element, textChangingSize) {
+    Tests::Tricks::createBackendSupport();
+
+    auto       text = CTextBuilder::begin()->text("First longish paragraph goes here. I love Hyprland it is the best.")->commence();
+
+    const auto FIRST_SIZE = text->preferredSize({0, 0});
+
+    text->rebuild()->fontSize(CFontSize::HT_FONT_H1)->commence();
+
+    const auto SECOND_SIZE = text->preferredSize({0, 0});
+
+    ASSERT_GT(SECOND_SIZE->x, FIRST_SIZE->x);
+    ASSERT_GT(SECOND_SIZE->y, FIRST_SIZE->y);
+
+    text.reset();
+}
+
+TEST(Element, textChangingContent) {
+    Tests::Tricks::createBackendSupport();
+
+    auto       text = CTextBuilder::begin()->text("First longish paragraph goes here.")->commence();
+
+    const auto FIRST_SIZE = text->preferredSize({0, 0});
+
+    text->rebuild()->text("First longish paragraph goes here but event longer")->commence();
+
+    const auto SECOND_SIZE = text->preferredSize({0, 0});
+
+    ASSERT_GT(SECOND_SIZE->x, FIRST_SIZE->x);
+
+    text.reset();
+}
+
+TEST(Element, textClampSize) {
+    Tests::Tricks::createBackendSupport();
+
+    auto       text = CTextBuilder::begin()->text("First longish paragraph goes here.")->commence();
+
+    const auto NATURAL_SIZE  = text->preferredSize({0, 0});
+    const auto CLAMPED_WIDTH = std::floor(NATURAL_SIZE->x * 3 / 4);
+
+    text->rebuild()->clampSize({CLAMPED_WIDTH, -1.0})->commence();
+
+    ASSERT_LE(text->preferredSize({0, 0})->x, CLAMPED_WIDTH);
+
+    text.reset();
+}
+
+TEST(Element, textCharPosition) {
+    Tests::Tricks::createBackendSupport();
+
+    auto text = CTextBuilder::begin()->text("First longish paragraph goes here.")->commence();
+
+    ASSERT_EQ(text->m_impl->getCursorPos(0), 0);
+    ASSERT_GT(text->m_impl->getCursorPos(1), 0);
+    ASSERT_GT(text->m_impl->getCursorPos(1000), 0);
+
+    text->rebuild()->text("")->commence();
+
+    ASSERT_EQ(text->m_impl->getCursorPos(0), 0);
+    ASSERT_EQ(text->m_impl->getCursorPos(1), 0);
 
     text.reset();
 }


### PR DESCRIPTION
Currently, the preferred size of text depends on the previous size, which leads to oscilations and weird edge cases where text may not grow correctly. This also removes hacks around text using the max size of the parent not the actual size it was given. This does not impact performance because the pango layout is cached.

This does the same thing as #121 