### PR TITLE
window: don't allocate a swapchain for 0x0 windows, handle reconfigure/next failures

### DIFF
--- a/src/window/IWaylandWindow.cpp
+++ b/src/window/IWaylandWindow.cpp
@@ -74,14 +74,25 @@ void IWaylandWindow::resizeSwapchain(const Vector2D& pixelSize) {
     if (!m_waylandState.swapchain)
         m_waylandState.swapchain = Aquamarine::CSwapchain::create(g_waylandPlatform->m_allocator, g_waylandBackend->m_aqBackend->getImplementations().at(0));
 
-    m_waylandState.swapchain->reconfigure(Aquamarine::SSwapchainOptions{
-        .length = 2,
-        .size   = pixelSize,
-        .format = g_waylandPlatform->m_dmabufFormats.at(0).drmFormat,
-    });
+    // the compositor can send a fractional-scale update before the first xdg
+    // configure, i.e. while logicalSize is still 0x0. allocating a swapchain
+    // for a zero-sized window makes no sense; wait for a real size.
+    if (pixelSize.x < 1 || pixelSize.y < 1)
+        return;
+
+    if (!m_waylandState.swapchain->reconfigure(Aquamarine::SSwapchainOptions{
+            .length = 2,
+            .size   = pixelSize,
+            .format = g_waylandPlatform->m_dmabufFormats.at(0).drmFormat,
+        }))
+        return;
 
     for (size_t i = 0; i < m_waylandState.wlBuffers.size(); ++i) {
-        m_waylandState.wlBuffers[i] = makeShared<CWaylandBuffer>(m_waylandState.swapchain->next(nullptr));
+        auto buf = m_waylandState.swapchain->next(nullptr);
+        if (!buf)
+            return;
+
+        m_waylandState.wlBuffers[i] = makeShared<CWaylandBuffer>(buf);
     }
 }
 


### PR DESCRIPTION
## Problem

A Wayland compositor may send `wp_fractional_scale_v1.preferred_scale` **before** the first xdg configure, i.e. while the window's logical size is still 0x0. On such an event, `CWaylandWindow`'s scale handler calls `onScaleUpdate()` → `configure(m_waylandState.logicalSize)` → `resizeSwapchain({0,0})`, which:

1. calls `CSwapchain::reconfigure()` with `.length = 2` and a zero size — under current aquamarine this clears the swapchain but leaves `options.length = 2` with zero buffers,
2. **ignores the `reconfigure()` return value**, and
3. unconditionally feeds `next()` results into `CWaylandBuffer`, which would also dereference a null buffer at `buffer->dmabuf()` if `next()` ever returned `nullptr`.

The result is a guaranteed `std::out_of_range` crash on the first render attempt:

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 1) >= this->size() (which is 0)

#8  Aquamarine::CSwapchain::next(int*)
#9  Hyprtoolkit::IWaylandWindow::resizeSwapchain(Hyprutils::Math::Vector2D const&)
#10 Hyprtoolkit::IWaylandWindow::configure(Hyprutils::Math::Vector2D const&, unsigned int)
#11 Hyprtoolkit::_CWpFractionalScaleV1PreferredScale(void*, void*, unsigned int)
```

Reproduced 100% of the time with hyprpolkitagent under niri on a fractional-scaled (150%) output.

## Fix

In `IWaylandWindow::resizeSwapchain()`:

- return early when the pixel size is zero — there is nothing to allocate yet; the subsequent xdg configure with the real size goes through the full path as before,
- check the `reconfigure()` return value and bail out on failure instead of proceeding with a stale swapchain,
- check `next()` for `nullptr` before constructing a `CWaylandBuffer` (which would null-deref otherwise).

After this, the previously guaranteed crash under niri + 150% fractional scaling is gone and the window renders/authenticates correctly.

Note: there is also an aquamarine-side inconsistency (the swapchain clearing branch leaves `options.length > 0` with zero buffers), which I've fixed separately in hyprwm/aquamarine — see hyprwm/aquamarine#379. The two are independent: either one alone stops the crash, but both should hold the invariant.
